### PR TITLE
fix: remove text/csv type from uploads accepted formats

### DIFF
--- a/packages/components/src/upload/Upload.js
+++ b/packages/components/src/upload/Upload.js
@@ -8,17 +8,7 @@ import './Upload.css';
 import ProcessIndicator from '../processIndicator';
 
 const PROCESS_STATE = ['error', 'success'];
-/*
- * Do not add `text/csv` to the accepted formats.
- * This mime type is not supported by win7 browsers.
- * At Win7 Chrome/Firefox/IE11 mime type looks empty, and so upload is blocked
- * Use `*` for `text/csv` and make type check in backend.
- * Reference:
- * https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/ms775147(v=vs.85)?redirectedfrom=MSDN
- * https://cs.chromium.org/chromium/src/net/base/mime_util.cc?q=mime&sq=package:chromium&g=0&l=1
- * https://transferwise.slack.com/archives/CJNBX9CP6/p1580208301003500
- */
-const ACCEPTED_FORMAT = ['*', 'image/*', 'application/*'];
+const ACCEPTED_FORMAT = ['*', 'image/*', 'application/*', 'text/csv'];
 
 /*
  * This delay is required for the isError/isSuccess to be fired after isProcessing so the processIndicator, will be

--- a/packages/components/src/upload/Upload.js
+++ b/packages/components/src/upload/Upload.js
@@ -8,7 +8,17 @@ import './Upload.css';
 import ProcessIndicator from '../processIndicator';
 
 const PROCESS_STATE = ['error', 'success'];
-const ACCEPTED_FORMAT = ['*', 'image/*', 'application/*', 'text/csv'];
+/*
+ * Do not add `text/csv` to the accepted formats.
+ * This mime type is not supported by win7 browsers.
+ * At Win7 Chrome/Firefox/IE11 mime type looks empty, and so upload is blocked
+ * Use `*` for `text/csv` and make type check in backend.
+ * Reference:
+ * https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/ms775147(v=vs.85)?redirectedfrom=MSDN
+ * https://cs.chromium.org/chromium/src/net/base/mime_util.cc?q=mime&sq=package:chromium&g=0&l=1
+ * https://transferwise.slack.com/archives/CJNBX9CP6/p1580208301003500
+ */
+const ACCEPTED_FORMAT = ['*', 'image/*', 'application/*'];
 
 /*
  * This delay is required for the isError/isSuccess to be fired after isProcessing so the processIndicator, will be

--- a/packages/components/src/upload/utils/isTypeValid/isTypeValid.js
+++ b/packages/components/src/upload/utils/isTypeValid/isTypeValid.js
@@ -1,4 +1,21 @@
 export const isTypeValid = (file, rule) => {
+  if (file.type === '') {
+    /*
+     * This text/csv mime type is not supported by windows browsers.
+     * At Windows Chrome/Firefox/IE11 mime type looks empty, and then upload is blocked
+     * To prevent this issue, there must be some additional checks if file type is empty.
+     *
+     * Reference:
+     * https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/ms775147(v=vs.85)?redirectedfrom=MSDN
+     * https://cs.chromium.org/chromium/src/net/base/mime_util.cc?q=mime&sq=package:chromium&g=0&l=1
+     * https://transferwise.slack.com/archives/CJNBX9CP6/p1580208301003500
+     */
+    const { navigator } = window;
+    if (navigator && navigator.platform && navigator.platform.includes('Win')) {
+      return true;
+    }
+  }
+
   if (rule === '*' || file.type === rule) {
     return true;
   }


### PR DESCRIPTION
BREAKING CHANGE: Remove text/csv from upload component's accepted formats

<!-- ☝️ make the title meaningful -->

## 📎 Jira ticket


## ❓ Context <!-- why this change is made --> 
At Win7 Chrome/Firefox/IE11 mime type looks empty, and so upload is blocked. Developer can forget about it, so it is better to remove `text/csv` support at all.

Edit: Skip type checking if mime type is empty string `""` and operation system is windows. 

https://transferwise.slack.com/archives/CJNBX9CP6/p1580208301003500

## 🚀 Changes <!-- what this PR does -->


## 💬 Considerations <!-- additional info for reviewing, discussion topics -->
Other workaround is, skipping type checking if it is empty string `""` , but this can cause unexpected results. There is no clear fix for this issue. 
Here are some discussions for the issue:

https://github.com/react-dropzone/react-dropzone/issues/391
https://github.com/danialfarid/ng-file-upload/issues/1211

## ✅ Checklist

- [ ] All changes are covered by tests
- [ ] The changes are covered in docs
- [x] The commits follow conventional commits standards