### PR TITLE
Add data models to values array in JSON schema forms

### DIFF
--- a/packages/components/src/formControl/FormControl.js
+++ b/packages/components/src/formControl/FormControl.js
@@ -292,7 +292,7 @@ export default class FormControl extends PureComponent {
             options={options}
             onChange={option => {
               this.setState({ selectedOption: option });
-              this.handleOnChange(option.value, option);
+              this.handleOnChange((option && option.value) || null, option);
             }}
             onFocus={this.handleOnFocus}
             onBlur={this.handleOnBlur}

--- a/packages/components/src/formControl/FormControl.js
+++ b/packages/components/src/formControl/FormControl.js
@@ -209,10 +209,9 @@ export default class FormControl extends PureComponent {
     return value;
   }
 
-  handleOnChange = event => {
+  handleOnChange = (event, option) => {
     const value = this.getValue(event);
-
-    this.props.onChange(value);
+    this.props.onChange(value, option);
   };
 
   handleOnFocus = event => this.props.onFocus && this.props.onFocus(this.getValue(event));
@@ -291,9 +290,9 @@ export default class FormControl extends PureComponent {
             id={id}
             selected={this.getSelectedOption(options)}
             options={options}
-            onChange={newValue => {
-              this.setState({ selectedOption: newValue });
-              this.handleOnChange(newValue);
+            onChange={option => {
+              this.setState({ selectedOption: option });
+              this.handleOnChange(option.value, option);
             }}
             onFocus={this.handleOnFocus}
             onBlur={this.handleOnBlur}

--- a/packages/components/src/jsonSchemaForm/JsonSchemaForm.story.js
+++ b/packages/components/src/jsonSchemaForm/JsonSchemaForm.story.js
@@ -6,6 +6,7 @@ import { boolean, select } from '@storybook/addon-knobs';
 import simpleSchema from './schemas/simple.json';
 import oneOfSchema from './schemas/oneOf.json';
 import allOfSchema from './schemas/allOf.json';
+import valuesDataSchema from './schemas/valuesData.json';
 
 export default {
   component: JsonSchemaForm,
@@ -17,6 +18,7 @@ export const basic = () => {
     simple: simpleSchema,
     oneOf: oneOfSchema,
     allOf: allOfSchema,
+    valuesData: valuesDataSchema,
   };
 
   const schema = select('schema', schemas, simpleSchema);

--- a/packages/components/src/jsonSchemaForm/basicTypeSchema/BasicTypeSchema.js
+++ b/packages/components/src/jsonSchemaForm/basicTypeSchema/BasicTypeSchema.js
@@ -9,15 +9,15 @@ import { getValidationFailures } from '../validation/validation-failures';
 import { getValidModelParts } from '../validation/valid-model';
 
 const BasicTypeSchema = props => {
-  const onChange = newModel => {
+  const onChange = (newModel, option) => {
     setChanged(true);
-    setModelAndBroadcast(sanitiseModel(newModel));
+    setModelAndBroadcast(sanitiseModel(newModel), option);
   };
 
   const getValidationKeys = newModel =>
     getValidationFailures(newModel, props.schema, props.required);
 
-  const setModelAndBroadcast = newModel => {
+  const setModelAndBroadcast = (newModel, option) => {
     setModel(newModel);
     const validationKeys = getValidationKeys(newModel);
     setValidations(validationKeys);
@@ -27,7 +27,7 @@ const BasicTypeSchema = props => {
     setLastModel(broadcastModel);
 
     if (broadcastModel !== lastModel) {
-      props.onChange(broadcastModel, props.schema);
+      props.onChange(broadcastModel, props.schema, option);
     }
   };
 
@@ -59,6 +59,7 @@ const BasicTypeSchema = props => {
   };
 
   const onModelChange = () => {
+    setModel(props.model);
     setValidations(getValidationKeys(model));
   };
 

--- a/packages/components/src/jsonSchemaForm/basicTypeSchema/BasicTypeSchema.spec.js
+++ b/packages/components/src/jsonSchemaForm/basicTypeSchema/BasicTypeSchema.spec.js
@@ -99,13 +99,15 @@ describe('Given a component for rendering basic type schemas', () => {
     });
 
     describe('when control triggers onChange with a valid value', () => {
+      let option;
       beforeEach(() => {
-        formControl.simulate('change', 'barbar');
+        option = { value: 'barbar', label: 'BARBAR' };
+        formControl.simulate('change', 'barbar', option);
         feedbackComponent = component.find(ControlFeedback);
       });
 
       it('should trigger the components onChange with the new value', () => {
-        expect(onChange).toHaveBeenCalledWith('barbar', schema);
+        expect(onChange).toHaveBeenCalledWith('barbar', schema, option);
       });
 
       it('should tell the ControlFeedback it has been changed', () => {
@@ -114,14 +116,16 @@ describe('Given a component for rendering basic type schemas', () => {
     });
 
     describe('when control triggers onChange with an invalid value', () => {
+      let option;
       beforeEach(() => {
-        formControl.simulate('change', 'f');
+        option = { value: 'f', label: 'F' };
+        formControl.simulate('change', 'f', option);
         feedbackComponent = component.find(ControlFeedback);
         formControl = component.find(SchemaFormControl);
       });
 
       it('should trigger the components onChange with null', () => {
-        expect(onChange).toHaveBeenCalledWith(null, schema);
+        expect(onChange).toHaveBeenCalledWith(null, schema, option);
       });
 
       it('should pass the correct validation to ControlFeedback component', () => {
@@ -139,7 +143,7 @@ describe('Given a component for rendering basic type schemas', () => {
 
     describe('when control changes to a value that resolves to false', () => {
       beforeEach(() => {
-        formControl.simulate('change', '');
+        formControl.simulate('change', '', { value: 'f', label: 'F' });
         feedbackComponent = component.find(ControlFeedback);
         formControl = component.find(SchemaFormControl);
       });
@@ -164,7 +168,7 @@ describe('Given a component for rendering basic type schemas', () => {
     });
 
     it('should call the onChange handler with the default ', () => {
-      expect(onChange).toHaveBeenCalledWith(schema.default, schema);
+      expect(onChange).toHaveBeenCalledWith(schema.default, schema, undefined);
     });
   });
 });

--- a/packages/components/src/jsonSchemaForm/genericSchema/GenericSchema.js
+++ b/packages/components/src/jsonSchemaForm/genericSchema/GenericSchema.js
@@ -6,18 +6,20 @@ import ObjectSchema from '../objectSchema/';
 import OneOfSchema from '../oneOfSchema/';
 import AllOfSchema from '../allOfSchema/';
 
-const GenericSchemaForm = props => (
-  <>
-    {props.schema.enum && <BasicTypeSchema {...props} />}
-    {props.schema.type === 'string' && <BasicTypeSchema {...props} />}
-    {props.schema.type === 'number' && <BasicTypeSchema {...props} />}
-    {props.schema.type === 'integer' && <BasicTypeSchema {...props} />}
-    {props.schema.type === 'boolean' && <BasicTypeSchema {...props} />}
-    {props.schema.type === 'object' && <ObjectSchema {...props} />}
-    {props.schema.oneOf && <OneOfSchema {...props} />}
-    {props.schema.allOf && <AllOfSchema {...props} />}
-  </>
-);
+const GenericSchemaForm = props => {
+  const isBasicType = schema => {
+    return schema.enum || ['string', 'number', 'integer', 'boolean'].includes(schema.type);
+  };
+
+  return (
+    <>
+      {isBasicType(props.schema) && <BasicTypeSchema {...props} />}
+      {props.schema.type === 'object' && <ObjectSchema {...props} />}
+      {props.schema.oneOf && <OneOfSchema {...props} />}
+      {props.schema.allOf && <AllOfSchema {...props} />}
+    </>
+  );
+};
 
 GenericSchemaForm.propTypes = {
   schema: Types.shape({

--- a/packages/components/src/jsonSchemaForm/objectSchema/ObjectSchema.js
+++ b/packages/components/src/jsonSchemaForm/objectSchema/ObjectSchema.js
@@ -7,14 +7,22 @@ import { getValidModelParts } from '../validation/valid-model';
 const ObjectSchema = props => {
   const [model, setModel] = useState({ ...(props.model || {}) });
 
-  const onChange = (propertyName, propertyModel, schema) => {
+  const onChange = (propertyName, propertyModel, schema, option) => {
+    let newModel = { ...model };
+
     if (propertyModel !== null) {
-      model[propertyName] = propertyModel;
+      newModel[propertyName] = propertyModel;
     } else {
-      delete model[propertyName];
+      delete newModel[propertyName];
     }
-    setModel(model);
-    props.onChange(model, schema);
+
+    // If this change was triggered by an option containing a data package, extend model.
+    if (option && option.data) {
+      newModel = { ...newModel, ...getValidModelParts(option.data, props.schema) };
+    }
+
+    setModel(newModel);
+    props.onChange(newModel, schema);
   };
 
   const getSchemaColumnClasses = width => {
@@ -47,11 +55,13 @@ const ObjectSchema = props => {
           >
             <GenericSchema
               schema={props.schema.properties[propertyName]}
-              model={props.model && props.model[propertyName]}
+              model={model && model[propertyName]}
               errors={props.errors && props.errors[propertyName]}
               locale={props.locale}
               translations={props.translations}
-              onChange={(newModel, schema) => onChange(propertyName, newModel, schema)}
+              onChange={(newModel, schema, option) =>
+                onChange(propertyName, newModel, schema, option)
+              }
               submitted={props.submitted}
               required={isRequired(propertyName)}
             />

--- a/packages/components/src/jsonSchemaForm/schemaFormControl/SchemaFormControl.js
+++ b/packages/components/src/jsonSchemaForm/schemaFormControl/SchemaFormControl.js
@@ -13,9 +13,9 @@ const SchemaFormControl = props => {
   const getSanitisedValue = value =>
     isNativeInput(props.schema.type) && (isNull(value) || isUndefined(value)) ? '' : value;
 
-  const onChange = value => {
+  const onChange = (value, option) => {
     // If the model does not satisfy the schema propogate null
-    props.onChange(getValidModelParts(value, props.schema));
+    props.onChange(getValidModelParts(value, props.schema), option);
   };
 
   const getControlType = schema => {
@@ -23,6 +23,9 @@ const SchemaFormControl = props => {
       return schema.control;
     }
 
+    if (schema.enum) {
+      return schema.enum.length >= 3 ? 'select' : 'radio';
+    }
     if (schema.type === 'string') {
       switch (schema.format) {
         case 'date':
@@ -37,9 +40,6 @@ const SchemaFormControl = props => {
     }
     if (schema.type === 'boolean') {
       return 'checkbox';
-    }
-    if (schema.enum) {
-      return schema.enum.length >= 3 ? 'select' : 'radio';
     }
     if (schema.type === 'integer') {
       return 'number';

--- a/packages/components/src/jsonSchemaForm/schemaFormControl/SchemaFormControl.spec.js
+++ b/packages/components/src/jsonSchemaForm/schemaFormControl/SchemaFormControl.spec.js
@@ -208,22 +208,26 @@ describe('Given a component for rendering a form control based on a schema', () 
   });
 
   describe('when the FormControl triggers onChange', () => {
+    let option;
     beforeEach(() => {
-      component.find(FormControl).simulate('change', 'new');
+      option = { value: 'new', label: 'NEW!' };
+      component.find(FormControl).simulate('change', 'new', option);
     });
 
     it('should trigger the components onChange handler', () => {
-      expect(onChange).toHaveBeenCalledWith('new');
+      expect(onChange).toHaveBeenCalledWith('new', option);
     });
   });
 
   describe('when the FormControl triggers onChange with an invalid value', () => {
+    let option;
     beforeEach(() => {
-      component.find(FormControl).simulate('change', 2);
+      option = { value: 2, label: 'TWO!' };
+      component.find(FormControl).simulate('change', 2, option);
     });
 
     it('should trigger the components onChange handler with null', () => {
-      expect(onChange).toHaveBeenCalledWith(null);
+      expect(onChange).toHaveBeenCalledWith(null, option);
     });
   });
 

--- a/packages/components/src/jsonSchemaForm/schemas/valuesData.json
+++ b/packages/components/src/jsonSchemaForm/schemas/valuesData.json
@@ -4,6 +4,7 @@
     "bankName": {
       "title": "Branch",
       "type": "string",
+      "placeholder": "Select your branch...",
       "values": [
         {
           "value": "12345",

--- a/packages/components/src/jsonSchemaForm/schemas/valuesData.json
+++ b/packages/components/src/jsonSchemaForm/schemas/valuesData.json
@@ -1,0 +1,47 @@
+{
+  "type": "object",
+  "properties": {
+    "bankName": {
+      "title": "Branch",
+      "type": "string",
+      "values": [
+        {
+          "value": "12345",
+          "label": "London - Oxford street",
+          "data": {
+            "streetAddress": "123 Oxford Street",
+            "city": "London"
+          }
+        },
+        {
+          "value": "12346",
+          "label": "London - Liverpool street",
+          "data": {
+            "streetAddress": "12 Liverpool Street",
+            "city": "London"
+          }
+        },
+        {
+          "value": "12347",
+          "label": "Bristol - Cabots Circus",
+          "data": {
+            "streetAddress": "1 Cabots Circus",
+            "city": "Bristol",
+            "invalid": "should be stripped"
+          }
+        }
+      ],
+      "enum": ["12345", "123456", "12347"]
+    },
+    "streetAddress": {
+      "title": "Street Address",
+      "type": "string",
+      "disabled": true
+    },
+    "city": {
+      "title": "City",
+      "type": "string",
+      "disabled": true
+    }
+  }
+}


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## 📎 Jira ticket


## ❓ Context <!-- why this change is made --> 
Adds the ability for enumerated field values to contain additional data.  On selection, this data should be merged with the parent model.

## 🚀 Changes <!-- what this PR does -->
Basic type schemas broadcast the full value as part of onChange.  The parent object schema combines any data package with its own model.
![values-data](https://user-images.githubusercontent.com/1318111/75900213-7c016d00-5e34-11ea-9442-18bf30aa796f.gif)

## 💬 Considerations <!-- additional info for reviewing, discussion topics -->


## ✅ Checklist

- [ ] All changes are covered by tests
- [x ] The changes are covered in docs
- [ x] The commits follow conventional commits standards