### PR TITLE
perf: use rollup & terser to reduce es bundle size

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -28,10 +28,8 @@
     "build:compile-css": "gulp lessCompiler",
     "build:umd": "NODE_ENV=umd rollup -c",
     "build:umd-nopolyfill": "NODE_ENV=umd-nopolyfill rollup -c",
-    "build:es": "NODE_ENV=es babel src -d build/es/polyfill --ignore '**/*.spec.js','**/*.story.js'",
-    "build:es-nopolyfill": "NODE_ENV=es-nopolyfill babel src -d build/es/no-polyfill --ignore '**/*.spec.js','**/*.story.js'",
-    "build:copy-files": "cpx 'src/**/!(db)/*.{css,json,svg}' build/es/polyfill",
-    "build:copy-files2": "cpx 'src/**/!(db)/*.{css,json,svg}' build/es/no-polyfill",
+    "build:es": "NODE_ENV=es rollup -c",
+    "build:es-nopolyfill": "NODE_ENV=es-nopolyfill rollup -c",
     "test": "gulp lessCompiler && jest --env=jsdom --runInBand && yarn test:bundleSize",
     "test:watch": "jest --watch --env=jsdom",
     "test:bundleSize": "bundlesize",
@@ -125,6 +123,7 @@
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-gzip": "^2.3.0",
     "rollup-plugin-postcss": "^2.0.3",
+    "rollup-plugin-terser": "^5.3.0",
     "rollup-plugin-uglify": "^6.0.4"
   },
   "peerDependencies": {

--- a/packages/components/rollup.config.js
+++ b/packages/components/rollup.config.js
@@ -3,13 +3,20 @@ import babel from 'rollup-plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import postcss from 'rollup-plugin-postcss';
 import { uglify } from 'rollup-plugin-uglify';
+import { terser } from 'rollup-plugin-terser';
 
 import pkg from './package.json';
 
+const env = {
+  'es-nopolyfill': { file: './build/es/no-polyfill/index.js', format: 'esm' },
+  es: { file: pkg.module, format: 'esm' },
+  'umd-nopolyfill': { file: './build/umd/no-polyfill/main.js', format: 'umd' },
+  umd: { file: pkg.main, format: 'umd' },
+};
+
 // Rollup
 const input = 'src/index.js';
-const file =
-  process.env.NODE_ENV === 'umd-nopolyfill' ? './build/umd/no-polyfill/main.js' : pkg.main;
+const { file, format } = env[process.env.NODE_ENV];
 
 // Rollup can resolve only explicit exports.
 // https://github.com/rollup/rollup/issues/2671
@@ -44,13 +51,13 @@ const plugins = [
     extract: pkg.style,
     extensions: ['.css'],
   }),
-  uglify(),
+  format === 'esm' ? terser() : uglify(),
 ];
 
 export default [
   {
     input,
-    output: [{ file, name: pkg.name, format: 'umd', globals }],
+    output: [{ file, name: pkg.name, format, globals }],
     external: [
       ...Object.keys(pkg.devDependencies || {}),
       ...Object.keys(pkg.peerDependencies || {}),

--- a/yarn.lock
+++ b/yarn.lock
@@ -17392,6 +17392,17 @@ rollup-plugin-postcss@^2.0.3:
     rollup-pluginutils "^2.0.1"
     style-inject "^0.3.0"
 
+rollup-plugin-terser@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz#9c0dd33d5771df9630cd027d6a2559187f65885e"
+  integrity sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    jest-worker "^24.9.0"
+    rollup-pluginutils "^2.8.2"
+    serialize-javascript "^2.1.2"
+    terser "^4.6.2"
+
 rollup-plugin-uglify@^6.0.4:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.4.tgz#65a0959d91586627f1e46a7db966fd504ec6c4e6"
@@ -17402,7 +17413,7 @@ rollup-plugin-uglify@^6.0.4:
     serialize-javascript "^2.1.2"
     uglify-js "^3.4.9"
 
-rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.8.1:
+rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
   integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
@@ -18752,6 +18763,15 @@ terser@^4.3.9:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.0.tgz#5c1f8d01897a718797958b8607ff7cc4a3d12055"
   integrity sha512-YMJyZ/KsqA1LVS0z5m9W1//n4zo6iYqvBSAvss07e4BfHl9ZdQWUeXN/Xh1nGzMO/CwS0zjANpOzR8KibBP9Pg==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
+
+terser@^4.6.2:
+  version "4.6.7"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.7.tgz#478d7f9394ec1907f0e488c5f6a6a9a2bad55e72"
+  integrity sha512-fmr7M1f7DBly5cX2+rFDvmGBAaaZyPrHYK4mMdHEDAdNTqXSZgSOfqsfGq2HqPGT/1V0foZZuCZFx8CHKgAk3g==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## 📎 Jira ticket
None

## ❓ Context <!-- why this change is made --> 
I was an [intern](https://github.com/jacklesliewise) last summer and I'm joining as a grad in August, I'm wanting to get to grips with Babel, Rollup etc so wanted to check out your setup. I noticed you use `babel-cli` to make the ES bundle and then copy the assets (e.g CSS) manually afterwards with `cpx`. I was wondering if you could use Rollup for this instead? 

I took a go at it and it's reduced the `es/no-polyfill` size from `313kb` to `232kb` and the `es/polyfill` size from `325kb` to `274kb`.

Really interested for input/feedback even if it's not needed, thanks in advance!

## 🚀 Changes <!-- what this PR does -->
- Removes the builds using `babel-cli` and removes the `copy-files` scripts
- Uses rollup to create the `es` and `es-nopolyfill` bundles
- Uses `rollup-plugin-terser` to minify ES bundle instead of `rollup-plugin-uglify` (uglify is for [es5](https://github.com/TrySound/rollup-plugin-uglify#rollup-plugin-uglify-) only)


## 💬 Considerations <!-- additional info for reviewing, discussion topics -->
- Is there a reason to use `babel-cli` and `cpx` instead of Rollup for ES bundles? The ES bundle previously still has it's file structure intact and was largely readable, is this why?
- Is the code style okay regarding the `env` object in `rollup.config.js`?
- Will more plugins be needed for `svg` and `json` assets as they were being copied over with `cpx`?


## ✅ Checklist

- [ ] All changes are covered by tests
- [ ] The changes are covered in docs
- [x] The commits follow conventional commits standards