### PR TITLE
feat: allow custom chip creation for typehead

### DIFF
--- a/packages/components/src/typeahead/Typeahead.js
+++ b/packages/components/src/typeahead/Typeahead.js
@@ -29,6 +29,7 @@ export default class Typeahead extends Component {
   static Type = MessageType;
   static propTypes = {
     id: Types.string.isRequired,
+    createChip: Types.func,
     name: Types.string.isRequired,
     options: Types.arrayOf(
       Types.shape({
@@ -77,6 +78,7 @@ export default class Typeahead extends Component {
     multiple: false,
     maxHeight: null,
     showSuggestions: true,
+    createChip: props => <Chip {...props} />,
     showNewEntry: true,
     searchDelay: SEARCH_DELAY,
     minQueryLength: DEFAULT_MIN_QUERY_LENGTH,
@@ -347,9 +349,9 @@ export default class Typeahead extends Component {
 
   renderChip = (option, idx) => {
     const valid = this.props.validateChip(option);
-
+    const { createChip: TypeHeadChip } = this.props;
     return (
-      <Chip
+      <TypeHeadChip
         key={idx}
         hasError={!valid}
         label={option.label}

--- a/packages/components/src/typeahead/Typeahead.story.js
+++ b/packages/components/src/typeahead/Typeahead.story.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Typeahead from './Typeahead';
+import Chip from '../chip';
 
 import { boolean } from '@storybook/addon-knobs';
 
@@ -63,6 +64,7 @@ export const basic = () => {
       placeholder="placeholder"
       chipSeparators={[',', ' ']}
       validateChip={validateChip}
+      createChip={props => <Chip {...props} />}
       alert={{ message: 'alert message', type: 'success' }}
       onSearch={() => {
         setTimeout(() => setOptions(options), 1500);

--- a/packages/docs/liveEditorCode/typeahead.code.js
+++ b/packages/docs/liveEditorCode/typeahead.code.js
@@ -48,6 +48,8 @@
       showSuggestions
       placeholder="placeholder"
       chipSeparators={[',', ' ']}
+      // add your custom chip render function here
+      createChip={undefined}
       validateChip={validateChip}
       alert={{ message: 'alert message', type: 'success' }}
       onSearch={() => {


### PR DESCRIPTION
##❓ Context <!-- why this change is made --> 
On users page we would like to display a tooltip when hovering the chip with error. To do so I have created a prop to pass a custom chip component.

## 🚀 Changes <!-- what this PR does -->
Custom chip component to typehead.

## 💬 Considerations <!-- additional info for reviewing, discussion topics -->


## ✅ Checklist

- [x] All changes are covered by tests
- [x] The changes are covered in docs
- [x] The commits follow conventional commits standards