### PR TITLE
docs: Mixpanel setup & Cookie banner & page tracking

### DIFF
--- a/packages/docs/components/Layout.js
+++ b/packages/docs/components/Layout.js
@@ -4,6 +4,8 @@ import { withRouter } from 'next/router';
 import Link from './Link';
 
 import { getFirstPageInSection, getPageFromPath } from '../utils/pageUtils';
+import { Events, trackingFromWeb, trackLink } from '../utils/mixpanel';
+
 import sections from '../utils/sections';
 
 import Sidebar from './Sidebar';
@@ -11,6 +13,10 @@ import Logo from '../static/assets/img/logo_full_inverse.svg';
 import ThreeColumnLayout from './layout/threeColumnLayout';
 
 const githubURL = `https://github.com/transferwise/neptune-web/edit/master/packages/docs/pages`;
+
+trackingFromWeb(() => {
+  trackLink('.Nav__Link', Events.PAGE_VIEWED, { page: window.location.pathname });
+});
 
 const Layout = ({ children, router: { pathname } }) => {
   const pathParts = pathname.split('/');

--- a/packages/docs/components/Layout.js
+++ b/packages/docs/components/Layout.js
@@ -4,7 +4,6 @@ import { withRouter } from 'next/router';
 import Link from './Link';
 
 import { getFirstPageInSection, getPageFromPath } from '../utils/pageUtils';
-import { Events, trackingFromWeb, trackLink } from '../utils/mixpanel';
 
 import sections from '../utils/sections';
 
@@ -13,10 +12,6 @@ import Logo from '../static/assets/img/logo_full_inverse.svg';
 import ThreeColumnLayout from './layout/threeColumnLayout';
 
 const githubURL = `https://github.com/transferwise/neptune-web/edit/master/packages/docs/pages`;
-
-trackingFromWeb(() => {
-  trackLink('.Nav__Link', Events.PAGE_VIEWED, { page: window.location.pathname });
-});
 
 const Layout = ({ children, router: { pathname } }) => {
   const pathParts = pathname.split('/');

--- a/packages/docs/components/Layout.js
+++ b/packages/docs/components/Layout.js
@@ -4,7 +4,6 @@ import { withRouter } from 'next/router';
 import Link from './Link';
 
 import { getFirstPageInSection, getPageFromPath } from '../utils/pageUtils';
-
 import sections from '../utils/sections';
 
 import Sidebar from './Sidebar';

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -18,9 +18,9 @@ const assetPrefix =
   process.env.NODE_ENV === 'production'
     ? `/neptune-web${branch !== 'master' ? `/branch/${branch}` : ''}`
     : '';
-const isProdInstance =
-  process.env.NODE_ENV === 'production' && (branch === 'master' || branch === 'mixpanel-setup');
-// const isProdInstance = true;
+// const isProdInstance =
+//   process.env.NODE_ENV === 'production' && (branch === 'master' || branch === 'mixpanel-setup');
+const isProdInstance = true;
 
 module.exports = () =>
   withTM(

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -13,14 +13,13 @@ const withTM = require('next-transpile-modules');
 
 const pageExtensions = ['js', 'mdx'];
 
+const isProdMode = process.env.NODE_ENV === 'production';
+
 const branch = getBranch.sync();
-const assetPrefix =
-  process.env.NODE_ENV === 'production'
-    ? `/neptune-web${branch !== 'master' ? `/branch/${branch}` : ''}`
-    : '';
-// const isProdInstance =
-//   process.env.NODE_ENV === 'production' && (branch === 'master' || branch === 'mixpanel-setup');
-const isProdInstance = true;
+const isMasterBranch = branch === 'master';
+
+const assetPrefix = isProdMode ? `/neptune-web${isMasterBranch ? '' : `/branch/${branch}`}` : '';
+const isProdInstance = isProdMode && isMasterBranch;
 
 module.exports = () =>
   withTM(
@@ -33,7 +32,7 @@ module.exports = () =>
             assetPrefix,
             env: {
               ASSET_PREFIX: assetPrefix,
-              isProdInstance,
+              IS_PROD_INSTANCE: isProdInstance,
             },
             webpack: (config) => {
               config.module.rules.push({

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -18,8 +18,9 @@ const assetPrefix =
   process.env.NODE_ENV === 'production'
     ? `/neptune-web${branch !== 'master' ? `/branch/${branch}` : ''}`
     : '';
-const isProdInstance =
-  process.env.NODE_ENV === 'production' && (branch === 'master' || branch === 'mixpanel-setup');
+// const isProdInstance =
+//   process.env.NODE_ENV === 'production' && (branch === 'master' || branch === 'mixpanel-setup');
+const isProdInstance = true;
 
 module.exports = () =>
   withTM(

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -19,7 +19,8 @@ const branch = getBranch.sync();
 const isMasterBranch = branch === 'master';
 
 const assetPrefix = isProdMode ? `/neptune-web${isMasterBranch ? '' : `/branch/${branch}`}` : '';
-const isProdInstance = isProdMode && isMasterBranch;
+// const isProdInstance = isProdMode && isMasterBranch;
+const isProdInstance = true;
 
 module.exports = () =>
   withTM(

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -18,6 +18,8 @@ const assetPrefix =
   process.env.NODE_ENV === 'production'
     ? `/neptune-web${branch !== 'master' ? `/branch/${branch}` : ''}`
     : '';
+// const isProdInstance = process.env.NODE_ENV === 'production' && branch === 'master';
+const isProdInstance = true;
 
 module.exports = () =>
   withTM(
@@ -30,6 +32,7 @@ module.exports = () =>
             assetPrefix,
             env: {
               ASSET_PREFIX: assetPrefix,
+              isProdInstance,
             },
             webpack: (config) => {
               config.module.rules.push({

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -18,9 +18,9 @@ const assetPrefix =
   process.env.NODE_ENV === 'production'
     ? `/neptune-web${branch !== 'master' ? `/branch/${branch}` : ''}`
     : '';
-// const isProdInstance =
-//   process.env.NODE_ENV === 'production' && (branch === 'master' || branch === 'mixpanel-setup');
-const isProdInstance = true;
+const isProdInstance =
+  process.env.NODE_ENV === 'production' && (branch === 'master' || branch === 'mixpanel-setup');
+// const isProdInstance = true;
 
 module.exports = () =>
   withTM(

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -18,8 +18,8 @@ const assetPrefix =
   process.env.NODE_ENV === 'production'
     ? `/neptune-web${branch !== 'master' ? `/branch/${branch}` : ''}`
     : '';
-// const isProdInstance = process.env.NODE_ENV === 'production' && branch === 'master';
-const isProdInstance = true;
+const isProdInstance =
+  process.env.NODE_ENV === 'production' && (branch === 'master' || branch === 'mixpanel-setup');
 
 module.exports = () =>
   withTM(

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -53,7 +53,8 @@
     "react-docgen": "5.3.0",
     "react-docgen-external-proptypes-handler": "^2.0.0",
     "react-live": "^2.2.2",
-    "rehype-slug": "^3.0.0"
+    "rehype-slug": "^3.0.0",
+    "mixpanel-browser": "^2.35.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/packages/docs/pages/_app.js
+++ b/packages/docs/pages/_app.js
@@ -5,7 +5,7 @@ import Head from 'next/head';
 import Router from 'next/router';
 import Layout from '../components/Layout';
 
-import { initMixpanel } from '../utils/mixpanel';
+import { Events, initMixpanel, trackingFromWeb, trackLink } from '../utils/mixpanel';
 
 import '@transferwise/neptune-css/dist/css/neptune.css';
 import 'currency-flags/dist/currency-flags.min.css';
@@ -16,6 +16,10 @@ import '../static/assets/main.css';
 class MyApp extends App {
   componentDidMount() {
     initMixpanel();
+    trackingFromWeb(() => {
+      console.log('trackingFromWeb');
+      trackLink('.Nav__Link', Events.PAGE_VIEWED, { page: window.location.pathname });
+    });
     const { pathname } = Router;
     if (pathname === '/') {
       Router.push(`${process.env.NODE_ENV === 'production' ? '/neptune-web/' : '/'}about/Home`);

--- a/packages/docs/pages/_app.js
+++ b/packages/docs/pages/_app.js
@@ -5,7 +5,7 @@ import Head from 'next/head';
 import Router from 'next/router';
 import Layout from '../components/Layout';
 
-import { Events, initMixpanel, trackingFromWeb, trackLink } from '../utils/mixpanel';
+import { Events, initMixpanel, trackLink } from '../utils/mixpanel';
 
 import '@transferwise/neptune-css/dist/css/neptune.css';
 import 'currency-flags/dist/currency-flags.min.css';
@@ -20,10 +20,7 @@ class MyApp extends App {
       Router.push(`${process.env.NODE_ENV === 'production' ? '/neptune-web/' : '/'}about/Home`);
     }
     initMixpanel();
-    trackingFromWeb(() => {
-      console.log('trackingFromWeb');
-      trackLink('.Nav__Link', Events.PAGE_VIEWED, { page: window.location.pathname });
-    });
+    trackLink('.Nav__Link', Events.PAGE_VIEWED, { page: window.location.pathname });
   }
 
   render() {

--- a/packages/docs/pages/_app.js
+++ b/packages/docs/pages/_app.js
@@ -15,15 +15,15 @@ import '../static/assets/main.css';
 
 class MyApp extends App {
   componentDidMount() {
+    const { pathname } = Router;
+    if (pathname === '/') {
+      Router.push(`${process.env.NODE_ENV === 'production' ? '/neptune-web/' : '/'}about/Home`);
+    }
     initMixpanel();
     trackingFromWeb(() => {
       console.log('trackingFromWeb');
       trackLink('.Nav__Link', Events.PAGE_VIEWED, { page: window.location.pathname });
     });
-    const { pathname } = Router;
-    if (pathname === '/') {
-      Router.push(`${process.env.NODE_ENV === 'production' ? '/neptune-web/' : '/'}about/Home`);
-    }
   }
 
   render() {

--- a/packages/docs/pages/_app.js
+++ b/packages/docs/pages/_app.js
@@ -4,6 +4,9 @@ import App from 'next/app';
 import Head from 'next/head';
 import Router from 'next/router';
 import Layout from '../components/Layout';
+
+import { initMixpanel } from '../utils/mixpanel';
+
 import '@transferwise/neptune-css/dist/css/neptune.css';
 import 'currency-flags/dist/currency-flags.min.css';
 import '@transferwise/icons/dist/icons.min.css';
@@ -12,6 +15,7 @@ import '../static/assets/main.css';
 
 class MyApp extends App {
   componentDidMount() {
+    initMixpanel();
     const { pathname } = Router;
     if (pathname === '/') {
       Router.push(`${process.env.NODE_ENV === 'production' ? '/neptune-web/' : '/'}about/Home`);
@@ -25,6 +29,7 @@ class MyApp extends App {
       <>
         <Head>
           <title>Neptune Design System — TransferWise</title>
+          <script src="https://transferwise.com/cookie-consent.js" />
         </Head>
 
         <Layout>

--- a/packages/docs/utils/mixpanel/index.js
+++ b/packages/docs/utils/mixpanel/index.js
@@ -11,11 +11,13 @@ export const Events = {
 };
 
 export function initMixpanel() {
+  console.log('initMixpanel');
   mixpanel.init('8ba4a7a5182f05e0a79ded57d5d2f051', {
     // We add "opt_out_tracking_by_default=true" and "opt_out_persistence_by_default=true" to mixpanel.init
     // so we don't set cookies and don't track customers before they give us their consent
     opt_out_tracking_by_default: true,
     opt_out_persistence_by_default: true,
+    // secure_cookie: true,
     debug: true,
   });
 

--- a/packages/docs/utils/mixpanel/index.js
+++ b/packages/docs/utils/mixpanel/index.js
@@ -1,7 +1,7 @@
 import mixpanel from 'mixpanel-browser';
 
 // we sent data to Mixpanel only from prod instance (https://transferwise.github.io/neptune-web)
-const { isProdInstance } = process.env;
+const { IS_PROD_INSTANCE } = process.env;
 
 export const Events = {
   /**
@@ -22,20 +22,12 @@ export function initMixpanel() {
   });
 
   window.addEventListener('accepttwcookieconsent', () => {
-    console.log("addEventListener('accepttwcookieconsent'");
     mixpanel.opt_in_tracking();
   });
 }
 
-export function trackingFromWeb(callback) {
-  // send event only from client (web) side
-  if (typeof window !== 'undefined') {
-    callback();
-  }
-}
-
 export function trackEvent(name, props) {
-  if (isProdInstance) {
+  if (IS_PROD_INSTANCE) {
     // https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpaneltrack
     mixpanel.track(eventNamePrefix(name), props);
   } else {
@@ -45,7 +37,7 @@ export function trackEvent(name, props) {
 }
 
 export function trackLink(selector, name, props) {
-  if (isProdInstance) {
+  if (IS_PROD_INSTANCE) {
     // https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpaneltrack_links
     mixpanel.track_links(selector, eventNamePrefix(name), props);
   } else {

--- a/packages/docs/utils/mixpanel/index.js
+++ b/packages/docs/utils/mixpanel/index.js
@@ -1,0 +1,57 @@
+import mixpanel from 'mixpanel-browser';
+
+// we sent data to Mixpanel only from prod instance (https://transferwise.github.io/neptune-web)
+const { isProdInstance } = process.env;
+
+export const Events = {
+  /**
+   * Event for tracking pages which user opens
+   */
+  PAGE_VIEWED: 'Page Viewed',
+};
+
+export function initMixpanel() {
+  mixpanel.init('8ba4a7a5182f05e0a79ded57d5d2f051', {
+    // We add "opt_out_tracking_by_default=true" and "opt_out_persistence_by_default=true" to mixpanel.init
+    // so we don't set cookies and don't track customers before they give us their consent
+    opt_out_tracking_by_default: true,
+    opt_out_persistence_by_default: true,
+    debug: true,
+  });
+
+  window.addEventListener('accepttwcookieconsent', () => {
+    console.log("addEventListener('accepttwcookieconsent'");
+    mixpanel.opt_in_tracking();
+  });
+}
+
+export function trackingFromWeb(callback) {
+  // send event only from client (web) side
+  if (typeof window !== 'undefined') {
+    callback();
+  }
+}
+
+export function trackEvent(name, props) {
+  if (isProdInstance) {
+    // https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpaneltrack
+    mixpanel.track(eventNamePrefix(name), props);
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(`Track Event '${name}', props`, props);
+  }
+}
+
+export function trackLink(selector, name, props) {
+  if (isProdInstance) {
+    // https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpaneltrack_links
+    mixpanel.track_links(selector, eventNamePrefix(name), props);
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(`Enabled Link tracking for '${selector}' selector, event: '${name}', props`, props);
+  }
+}
+
+function eventNamePrefix(name) {
+  return `Neptune - ${name}`;
+}


### PR DESCRIPTION
**Link to deployed changes: https://transferwise.github.io/neptune-web/branch/mixpanel-setup/about/Home**

## ❓Context <!-- why this change is made --> 

We want to start tracking Neptune Docs usage.

## 🚀 Changes <!-- what this PR does -->

Add Mixpanel, configure it and enable tracking for all pages.

Example of events: https://mixpanel.com/s/2w49R1

Plus, add yummy cookie banner so users can opt in or out using cookies usage, for that we use same script which on transferwise.com domain the [cookie-consent-js](https://github.com/transferwise/cookie-consent-js).

---

Tracking is happens on clicking by element with `.Nav__Link` CSS class.

## 💬 Considerations <!-- additional info for reviewing, discussion topics -->


## ✅ Checklist

- [ ] All changes are covered by tests
- [ ] The changes are covered in docs
- [ ] The commits follow conventional commits standards