### PR TITLE
feat: add umd export for dynamic flows

### DIFF
--- a/packages/dynamic-flows/babel.config.js
+++ b/packages/dynamic-flows/babel.config.js
@@ -1,3 +1,39 @@
+const umdConfig = {
+  presets: [
+    [
+      // @babel/preset-env is a smart preset that allows you to use the latest JavaScript without needing to micromanage which
+      // syntax transforms (and optionally, browser polyfills) are needed by your target environment(s).
+      '@babel/preset-env',
+      {
+        // This option configures how @babel/preset-env handles polyfills.
+        // useBuiltIns: 'usage' Adds specific imports for polyfills when they are used in each file.
+        // We take advantage of the fact that a bundler will load the same polyfill only once.
+        useBuiltIns: 'usage',
+        corejs: '3.0.0',
+        // targets: {
+        //   browsers: please check browserlistrc.
+        // },
+        // Do not transform ES6 module syntax to another module type.
+        // Rollup requires that your Babel configuration keeps ES6 module syntax intact
+        modules: false,
+      },
+    ],
+  ],
+};
+
+const umdConfigNoPolyfill = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        // Don't add polyfills automatically per file, and don't transform import "core-js" or import "@babel/polyfill" to individual polyfills.
+        useBuiltIns: false,
+        modules: false,
+      },
+    ],
+  ],
+};
+
 const esConfig = {
   presets: [
     [
@@ -56,6 +92,8 @@ module.exports = {
   ],
   env: {
     test: testConfig,
+    umd: umdConfig,
+    'umd-nopolyfill': umdConfigNoPolyfill,
     es: esConfig,
     'es-nopolyfill': esConfigNoPolyfill,
   },

--- a/packages/dynamic-flows/package.json
+++ b/packages/dynamic-flows/package.json
@@ -3,7 +3,7 @@
   "version": "2.2.3",
   "description": "Transferwise dynamic flows and forms",
   "license": "Apache-2.0",
-  "main": "./build/es/polyfill/index.js",
+  "main": "./build/umd/polyfill/index.js",
   "module": "./build/es/polyfill/index.js",
   "style": "./build/main.css",
   "sideEffects": [
@@ -27,6 +27,8 @@
     "build": "npm-run-all build:*",
     "build:clean": "rm -rf lib build",
     "build:compile-css": "gulp lessCompiler --gulpfile=../../node_modules/@transferwise/less-config --dest=src",
+    "build:umd": "NODE_ENV=umd rollup -c",
+    "build:umd-nopolyfill": "NODE_ENV=umd-nopolyfill rollup -c",
     "build:es": "NODE_ENV=es babel src -d build/es/polyfill --ignore '**/*.spec.js','**/*.story.js'",
     "build:es-nopolyfill": "NODE_ENV=es-nopolyfill babel src -d build/es/no-polyfill --ignore '**/*.spec.js','**/*.story.js'",
     "build:copy-files": "cpx 'src/**/!(db)/*.{css,json,svg}' build/es/polyfill",
@@ -43,6 +45,9 @@
     "@babel/plugin-transform-react-jsx": "^7.9.0",
     "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/preset-env": "^7.4.5",
+    "@rollup/plugin-commonjs": "^11.0.2",
+    "@rollup/plugin-json": "^4.0.3",
+    "@rollup/plugin-node-resolve": "^7.1.3",
     "@storybook/addon-a11y": "^5.3.18",
     "@storybook/addon-actions": "^5.3.18",
     "@storybook/addon-info": "^5.3.18",
@@ -51,7 +56,11 @@
     "@transferwise/less-config": "^1.0.1",
     "@transferwise/test-config": "^1.0.1",
     "babel-loader": "^8.1.0",
-    "babel-preset-minify": "^0.5.1"
+    "babel-preset-minify": "^0.5.1",
+    "rollup": "^2.7.6",
+    "rollup-plugin-babel": "^4.4.0",
+    "rollup-plugin-postcss": "^2.0.3",
+    "rollup-plugin-uglify": "^6.0.4"
   },
   "peerDependencies": {
     "bootstrap": "github:transferwise/bootstrap#semver:^5.20.0",

--- a/packages/dynamic-flows/rollup.config.js
+++ b/packages/dynamic-flows/rollup.config.js
@@ -1,0 +1,62 @@
+import resolve from '@rollup/plugin-node-resolve';
+import babel from 'rollup-plugin-babel';
+import commonjs from '@rollup/plugin-commonjs';
+import postcss from 'rollup-plugin-postcss';
+import { uglify } from 'rollup-plugin-uglify';
+import json from '@rollup/plugin-json';
+
+import pkg from './package.json';
+
+// Rollup
+const input = 'src/index.js';
+const file =
+  process.env.NODE_ENV === 'umd-nopolyfill' ? './build/umd/no-polyfill/main.js' : pkg.main;
+
+// Rollup can resolve only explicit exports.
+// https://github.com/rollup/rollup/issues/2671
+// https://github.com/rollup/rollup-plugin-commonjs
+const namedExports = {
+  '../../node_modules/@transferwise/formatting/dist/formatting.js': [
+    'formatAmount',
+    'formatMoney',
+    'formatDate',
+    'formatNumber',
+  ],
+};
+
+const globals = {
+  react: 'React',
+  'react-dom': 'ReactDOM',
+  'prop-types': 'PropTypes',
+};
+
+// Plugins
+const plugins = [
+  // Resolves modules from node_modules
+  resolve(),
+  babel({
+    runtimeHelpers: true,
+    exclude: ['node_modules/**', '../../node_modules/**'],
+  }),
+  // Convert CJ into ES6
+  commonjs({ sourcemap: false, namedExports }),
+  postcss({
+    config: true,
+    extract: pkg.style,
+    extensions: ['.css'],
+  }),
+  json(),
+  uglify(),
+];
+
+export default [
+  {
+    input,
+    output: [{ file, name: pkg.name, format: 'umd', globals }],
+    external: [
+      ...Object.keys(pkg.devDependencies || {}),
+      ...Object.keys(pkg.peerDependencies || {}),
+    ],
+    plugins,
+  },
+];


### PR DESCRIPTION


☝️ make the title meaningful and follow conventional commits standards

## 📎 Jira ticket



## ❓ Context <!-- why this change is made --> 

Jest doesn't support ES modules yet, so having a UMD module allows Jest
to use dynamic-flows without having to add additional compilation steps.

Config is entirely copy-pasted from components

## 🚀 Changes <!-- what this PR does -->

Adds a UMD export for dynamic-flows

## 💬 Considerations <!-- additional info for reviewing (e.g links to Mockups, docs etc.), discussion topics -->


## ✅ Checklist

- [x] All changes are covered by tests
- [ ] All changes have been crossbrowser checked, especially IE11
		Not relevant, no components changed
- [x] The changes are covered in docs
