### PR TITLE
feat: upload component helper image

### DIFF
--- a/packages/components/src/upload/Upload.js
+++ b/packages/components/src/upload/Upload.js
@@ -342,7 +342,7 @@ Upload.propTypes = {
   usButtonText: Types.string,
   usDisabled: Types.bool,
   usDropMessage: Types.string,
-  usHelpImage: Types.string,
+  usHelpImage: Types.oneOfType([Types.string, Types.node]),
   usLabel: Types.string,
   usPlaceholder: Types.string,
 };

--- a/packages/components/src/upload/Upload.story.js
+++ b/packages/components/src/upload/Upload.story.js
@@ -66,3 +66,38 @@ export const basic = () => {
     />
   );
 };
+
+export const withCustomImage = () => {
+  const size = select('size', ['sm', 'md', 'lg'], 'md');
+  return (
+    <Upload
+      animationDelay={700}
+      csUploadText="Select other file?"
+      csFailureText="Upload failed.Please, try again"
+      csSuccessText="Upload complete!"
+      csTooLargeMessage="Please provide a file smaller than 5MB"
+      csWrongTypeMessage="Please provide a supported format"
+      maxSize={5000000}
+      psUploadText="Cancel"
+      psFailureText="Upload failed.Please, try again"
+      psProcessingText="Uploading..."
+      psSuccessText="Upload complete!"
+      size={size}
+      usAccept="image/*"
+      usUploadText="Or Select File"
+      usDisabled={false}
+      usDropMessage="Drop file to start upload"
+      usLabel=""
+      usPlaceholder="Drag and drop file less than 5MB"
+      usHelpImage={<img src={IMAGES[0].value} alt="test" />}
+      httpOptions={{
+        url: 'https://httpbin.org/post',
+        method: 'POST',
+      }}
+      onStart={(file) => action('onStart', file)}
+      onSuccess={(httpResponse, fileName) => action('onSuccess', httpResponse, fileName)}
+      onFailure={(httpResponse) => action('onFailure', httpResponse)}
+      onCancel={() => action('onCancel')}
+    />
+  );
+};

--- a/packages/components/src/upload/steps/uploadImageStep/uploadImageStep.js
+++ b/packages/components/src/upload/steps/uploadImageStep/uploadImageStep.js
@@ -9,7 +9,7 @@ class UploadImageStep extends PureComponent {
     usAccept: Types.string.isRequired,
     usButtonText: Types.string.isRequired,
     usDisabled: Types.bool.isRequired,
-    usHelpImage: Types.string.isRequired,
+    usHelpImage: Types.oneOfType([Types.string, Types.node]).isRequired,
     usLabel: Types.string.isRequired,
     usPlaceholder: Types.string.isRequired,
   };
@@ -43,9 +43,10 @@ class UploadImageStep extends PureComponent {
         <div className="droppable-default-card" aria-hidden={isComplete}>
           <div className="droppable-card-content">
             <div className="m-b-3">
-              {usHelpImage && (
+              {typeof usHelpImage === 'string' && (
                 <img src={usHelpImage} alt={usLabel} className="thumbnail text-xs-center" />
               )}
+              {!!usHelpImage && usHelpImage}
               {!usHelpImage && (
                 <div className="circle circle-sm circle-inverse p-t-1">
                   <Upload size="md" />

--- a/packages/components/src/upload/steps/uploadImageStep/uploadImageStep.spec.js
+++ b/packages/components/src/upload/steps/uploadImageStep/uploadImageStep.spec.js
@@ -52,4 +52,15 @@ describe('uploadImageStep', () => {
   it('renders input file', () => {
     expect(component.find('input[type="file"]')).toHaveLength(1);
   });
+
+  it('renders a custom usHelpImage file', () => {
+    component = shallow(
+      <UploadImageStep
+        {...UPLOADIMAGE_STEP_PROPS}
+        usHelpImage={<img src="https://test.com" alt="test" className="test-image" />}
+      />,
+    );
+
+    expect(component.find('.test-image')).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## ❓ Context
The design of the profile picture upload component uses a Lottie animated image as helper image in the upload component.

## 🚀 Changes 
Changed the upload component to handle components as helper image.



## ✅ Checklist

- [x] All changes are covered by tests
- [x] All changes have been crossbrowser checked, especially IE11
- [x] The changes are covered in docs
