### PR TITLE
perf: remove propTypes from components and dynamic-flows build

### DIFF
--- a/packages/components/babel.config.js
+++ b/packages/components/babel.config.js
@@ -79,6 +79,7 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-react-jsx',
     '@babel/plugin-transform-runtime',
+    'transform-react-remove-prop-types',
   ],
   env: {
     test: testConfig,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -57,6 +57,7 @@
     "@transferwise/less-config": "^1.0.1",
     "@transferwise/test-config": "^1.0.1",
     "babel-loader": "^8.1.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "babel-preset-minify": "^0.5.1",
     "bundlesize": "^0.18.0",
     "lodash.times": "^4.3.2",

--- a/packages/dynamic-flows/babel.config.js
+++ b/packages/dynamic-flows/babel.config.js
@@ -53,6 +53,7 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-react-jsx',
     '@babel/plugin-transform-runtime',
+    'transform-react-remove-prop-types',
   ],
   env: {
     test: testConfig,

--- a/packages/dynamic-flows/package.json
+++ b/packages/dynamic-flows/package.json
@@ -51,6 +51,7 @@
     "@transferwise/less-config": "^1.0.1",
     "@transferwise/test-config": "^1.0.1",
     "babel-loader": "^8.1.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "babel-preset-minify": "^0.5.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5120,7 +5120,7 @@ babel-plugin-transform-property-literals@^6.9.4:
   dependencies:
     esutils "^2.0.2"
 
-babel-plugin-transform-react-remove-prop-types@0.4.24:
+babel-plugin-transform-react-remove-prop-types@0.4.24, babel-plugin-transform-react-remove-prop-types@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
   integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==


### PR DESCRIPTION
☝️ make the title meaningful and follow conventional commits standards

## 📎 Jira ticket
N/A

## ❓ Context <!-- why this change is made --> 
[This babel plugin](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types) removes `propTypes` declarations from production builds (it was featured in [this Google Chrome list](https://github.com/GoogleChromeLabs/webpack-libs-optimizations#react) of recommendations for webpack library optimisations) and thought I'd make a PR. It's also used internally by [Next.js](https://github.com/vercel/next.js/blob/e125d905a0dd93d247c6122d349c2c90268f0713/packages/next/build/babel/preset.ts#L176) to reduce build sizes (hence why it was already in the `yarn.lock` file)

## 🚀 Changes <!-- what this PR does -->
Adds `babel-plugin-transform-react-remove-prop-types` to `babel.config.js` in the `components` and `dynamic-flows` packages. It reduces bundles sizes (in filesystem) as follows:

### `components`
- `es/no-polyfill`: `264kb` -> `242kb`
- `es/polyfill`: `272kb` -> `250kb`
- `umd/no-polyfill`: `340kb` -> `323kb`
- `umd/polyfill`: `381kb` -> `364kb`

### `dynamic-flows`
- `es/no-polyfill`: `127kb` -> `118kb`
- `es/polyfill`: `132kb` -> `123kb`

## 💬 Considerations <!-- additional info for reviewing (e.g links to Mockups, docs etc.), discussion topics -->
This only applies to functional components, class components which use `static` propTypes won't benefit from this. In the Google Chrome list it is flagged as "safe to use by default". I didn't do any testing beyond symlinking locally and running storybook.

## ✅ Checklist

- [ ] All changes are covered by tests
- [ ] All changes have been crossbrowser checked, especially IE11
- [ ] The changes are covered in docs
