### PR TITLE
perf: remove propTypes from components and dynamic-flows build 

### DIFF
--- a/packages/components/babel.config.js
+++ b/packages/components/babel.config.js
@@ -19,7 +19,6 @@ const umdConfig = {
       },
     ],
   ],
-  plugins: ['transform-react-remove-prop-types'],
 };
 
 const umdConfigNoPolyfill = {
@@ -33,7 +32,6 @@ const umdConfigNoPolyfill = {
       },
     ],
   ],
-  plugins: ['transform-react-remove-prop-types'],
 };
 
 const esConfig = {
@@ -51,7 +49,6 @@ const esConfig = {
     ],
     ['minify', { builtIns: false, mangle: { exclude: { separators: true } } }],
   ],
-  plugins: ['transform-react-remove-prop-types'],
 };
 
 const esConfigNoPolyfill = {
@@ -59,7 +56,6 @@ const esConfigNoPolyfill = {
     ['@babel/preset-env', { useBuiltIns: false, modules: false }],
     ['minify', { builtIns: false, mangle: { exclude: { separators: true } } }],
   ],
-  plugins: ['transform-react-remove-prop-types'],
 };
 
 const testConfig = {
@@ -83,6 +79,7 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-react-jsx',
     '@babel/plugin-transform-runtime',
+    'transform-react-remove-prop-types',
   ],
   env: {
     test: testConfig,

--- a/packages/components/babel.config.js
+++ b/packages/components/babel.config.js
@@ -79,6 +79,7 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-react-jsx',
     '@babel/plugin-transform-runtime',
+    'transform-react-remove-prop-types',
   ],
   env: {
     test: testConfig,

--- a/packages/components/babel.config.js
+++ b/packages/components/babel.config.js
@@ -19,6 +19,7 @@ const umdConfig = {
       },
     ],
   ],
+  plugins: ['transform-react-remove-prop-types'],
 };
 
 const umdConfigNoPolyfill = {
@@ -32,6 +33,7 @@ const umdConfigNoPolyfill = {
       },
     ],
   ],
+  plugins: ['transform-react-remove-prop-types'],
 };
 
 const esConfig = {
@@ -49,6 +51,7 @@ const esConfig = {
     ],
     ['minify', { builtIns: false, mangle: { exclude: { separators: true } } }],
   ],
+  plugins: ['transform-react-remove-prop-types'],
 };
 
 const esConfigNoPolyfill = {
@@ -56,6 +59,7 @@ const esConfigNoPolyfill = {
     ['@babel/preset-env', { useBuiltIns: false, modules: false }],
     ['minify', { builtIns: false, mangle: { exclude: { separators: true } } }],
   ],
+  plugins: ['transform-react-remove-prop-types'],
 };
 
 const testConfig = {
@@ -79,7 +83,6 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-react-jsx',
     '@babel/plugin-transform-runtime',
-    'transform-react-remove-prop-types',
   ],
   env: {
     test: testConfig,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -57,6 +57,7 @@
     "@transferwise/less-config": "^1.0.1",
     "@transferwise/test-config": "^1.0.1",
     "babel-loader": "^8.1.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "babel-preset-minify": "^0.5.1",
     "bundlesize": "^0.18.0",
     "lodash.times": "^4.3.2",

--- a/packages/dynamic-flows/babel.config.js
+++ b/packages/dynamic-flows/babel.config.js
@@ -53,6 +53,7 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-react-jsx',
     '@babel/plugin-transform-runtime',
+    'transform-react-remove-prop-types',
   ],
   env: {
     test: testConfig,

--- a/packages/dynamic-flows/babel.config.js
+++ b/packages/dynamic-flows/babel.config.js
@@ -18,7 +18,6 @@ const esConfig = {
       },
     ],
   ],
-  plugins: ['transform-react-remove-prop-types'],
 };
 
 const esConfigNoPolyfill = {
@@ -31,7 +30,6 @@ const esConfigNoPolyfill = {
       },
     ],
   ],
-  plugins: ['transform-react-remove-prop-types'],
 };
 
 const testConfig = {
@@ -55,6 +53,7 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-react-jsx',
     '@babel/plugin-transform-runtime',
+    'transform-react-remove-prop-types',
   ],
   env: {
     test: testConfig,

--- a/packages/dynamic-flows/babel.config.js
+++ b/packages/dynamic-flows/babel.config.js
@@ -18,6 +18,7 @@ const esConfig = {
       },
     ],
   ],
+  plugins: ['transform-react-remove-prop-types'],
 };
 
 const esConfigNoPolyfill = {
@@ -30,6 +31,7 @@ const esConfigNoPolyfill = {
       },
     ],
   ],
+  plugins: ['transform-react-remove-prop-types'],
 };
 
 const testConfig = {
@@ -53,7 +55,6 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-react-jsx',
     '@babel/plugin-transform-runtime',
-    'transform-react-remove-prop-types',
   ],
   env: {
     test: testConfig,

--- a/packages/dynamic-flows/package.json
+++ b/packages/dynamic-flows/package.json
@@ -51,6 +51,7 @@
     "@transferwise/less-config": "^1.0.1",
     "@transferwise/test-config": "^1.0.1",
     "babel-loader": "^8.1.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "babel-preset-minify": "^0.5.1"
   },
   "peerDependencies": {

--- a/packages/dynamic-flows/src/formControl/FormControl.spec.js
+++ b/packages/dynamic-flows/src/formControl/FormControl.spec.js
@@ -45,14 +45,14 @@ describe('FormControl', () => {
   //   testTextControlValidation('password', 'input[type="password"]');
   //   testTextControlValidation('textarea', 'textarea');
 
-  testCustomControl('select', Select, <Select />);
-  testCustomControl('date', DateInput, <DateInput />);
-  testCustomControl('tel', PhoneNumberInput, <PhoneNumberInput />);
-  testCustomControl('checkbox', Checkbox, <Checkbox />);
-  testCustomControl('upload', Upload, <Upload />);
-  testCustomControl('text', InputWithDisplayFormat, <InputWithDisplayFormat />);
-  testCustomControl('textarea', TextareaWithDisplayFormat, <TextareaWithDisplayFormat />);
-  testCustomControl('date-lookup', DateLookup, <DateLookup />);
+  testCustomControl('select', Select);
+  testCustomControl('date', DateInput);
+  testCustomControl('tel', PhoneNumberInput);
+  testCustomControl('checkbox', Checkbox);
+  testCustomControl('upload', Upload);
+  testCustomControl('text', InputWithDisplayFormat);
+  testCustomControl('textarea', TextareaWithDisplayFormat);
+  testCustomControl('date-lookup', DateLookup);
 
   // testAutoComplete('text', 'input');
   // testAutoComplete('number', 'input');
@@ -478,13 +478,15 @@ describe('FormControl', () => {
     return { ...defaultProps, ...customProps };
   }
 
-  function getPropsToPassDown(controlType, customComponentJsx) {
+  function getPropsToPassDown(controlType, CustomComponent) {
     const PROPS = Object.keys(getPropsForControlType(controlType));
 
-    return Object.keys(customComponentJsx.props).filter((key) => PROPS.includes(key));
+    const customComponentWrapper = mount(<CustomComponent onChange={jest.fn()} options={[]} />);
+
+    return Object.keys(customComponentWrapper.props()).filter((key) => PROPS.includes(key));
   }
 
-  function testCustomControl(controlType, customComponent, customComponentJsx) {
+  function testCustomControl(controlType, CustomComponent) {
     let custom;
 
     const EVENT = {
@@ -493,15 +495,15 @@ describe('FormControl', () => {
       onFocus: 'focus',
     };
 
-    const PASSED_DOWN_PROPS = getPropsToPassDown(controlType, customComponentJsx);
+    const PASSED_DOWN_PROPS = getPropsToPassDown(controlType, CustomComponent);
     const CALLBACK_PROPS = ['onChange', 'onBlur', 'onFocus'];
 
     if (!controlType) {
       throw new Error('Missing mandatory value in `controlType` argument!');
     }
 
-    if (!customComponent) {
-      throw new Error('Missing mandatory value in `customComponent` argument!');
+    if (!CustomComponent) {
+      throw new Error('Missing mandatory value in `CustomComponent` argument!');
     }
 
     describe(`type: ${controlType}`, () => {
@@ -510,7 +512,7 @@ describe('FormControl', () => {
         component = shallow(
           <FormControl {...{ ...defaultProps, ...props }} displayPattern="**-**" />,
         );
-        const child = component.find(customComponent);
+        const child = component.find(CustomComponent);
         custom = child.length > 1 ? child.first() : child;
       });
 
@@ -524,7 +526,7 @@ describe('FormControl', () => {
           const TEST_FILE = new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' });
           component = mount(<FormControl {...{ ...defaultProps, ...props }} />);
 
-          component.find(customComponent).instance().fileDropped(TEST_FILE);
+          component.find(CustomComponent).instance().fileDropped(TEST_FILE);
 
           expect(props.onChange).toHaveBeenCalled();
         });

--- a/packages/dynamic-flows/src/formControl/FormControl.spec.js
+++ b/packages/dynamic-flows/src/formControl/FormControl.spec.js
@@ -45,14 +45,14 @@ describe('FormControl', () => {
   //   testTextControlValidation('password', 'input[type="password"]');
   //   testTextControlValidation('textarea', 'textarea');
 
-  testCustomControl('select', Select);
-  testCustomControl('date', DateInput);
-  testCustomControl('tel', PhoneNumberInput);
-  testCustomControl('checkbox', Checkbox);
-  testCustomControl('upload', Upload);
-  testCustomControl('text', InputWithDisplayFormat);
-  testCustomControl('textarea', TextareaWithDisplayFormat);
-  testCustomControl('date-lookup', DateLookup);
+  testCustomControl('select', Select, <Select />);
+  testCustomControl('date', DateInput, <DateInput />);
+  testCustomControl('tel', PhoneNumberInput, <PhoneNumberInput />);
+  testCustomControl('checkbox', Checkbox, <Checkbox />);
+  testCustomControl('upload', Upload, <Upload />);
+  testCustomControl('text', InputWithDisplayFormat, <InputWithDisplayFormat />);
+  testCustomControl('textarea', TextareaWithDisplayFormat, <TextareaWithDisplayFormat />);
+  testCustomControl('date-lookup', DateLookup, <DateLookup />);
 
   // testAutoComplete('text', 'input');
   // testAutoComplete('number', 'input');
@@ -478,13 +478,13 @@ describe('FormControl', () => {
     return { ...defaultProps, ...customProps };
   }
 
-  function getPropsToPassDown(controlType, customComponent) {
+  function getPropsToPassDown(controlType, customComponentJsx) {
     const PROPS = Object.keys(getPropsForControlType(controlType));
 
-    return Object.keys(customComponent.propTypes).filter((key) => PROPS.includes(key));
+    return Object.keys(customComponentJsx.props).filter((key) => PROPS.includes(key));
   }
 
-  function testCustomControl(controlType, customComponent) {
+  function testCustomControl(controlType, customComponent, customComponentJsx) {
     let custom;
 
     const EVENT = {
@@ -493,7 +493,7 @@ describe('FormControl', () => {
       onFocus: 'focus',
     };
 
-    const PASSED_DOWN_PROPS = getPropsToPassDown(controlType, customComponent);
+    const PASSED_DOWN_PROPS = getPropsToPassDown(controlType, customComponentJsx);
     const CALLBACK_PROPS = ['onChange', 'onBlur', 'onFocus'];
 
     if (!controlType) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5120,7 +5120,7 @@ babel-plugin-transform-property-literals@^6.9.4:
   dependencies:
     esutils "^2.0.2"
 
-babel-plugin-transform-react-remove-prop-types@0.4.24:
+babel-plugin-transform-react-remove-prop-types@0.4.24, babel-plugin-transform-react-remove-prop-types@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
   integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==


### PR DESCRIPTION
☝️ make the title meaningful and follow conventional commits standards

## 📎 Jira ticket
N/A

## ❓ Context <!-- why this change is made --> 
[This babel plugin](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types) removes `propTypes` declarations from production builds (it was featured in [this Google Chrome list](https://github.com/GoogleChromeLabs/webpack-libs-optimizations#react) of recommendations for webpack library optimisations) and thought I'd make a PR. It's also used internally by [Next.js](https://github.com/vercel/next.js/blob/e125d905a0dd93d247c6122d349c2c90268f0713/packages/next/build/babel/preset.ts#L176) to reduce build sizes (hence why it was already in the `yarn.lock` file)

## 🚀 Changes <!-- what this PR does -->
Adds `babel-plugin-transform-react-remove-prop-types` plugin to `babel.config.js` in the `components` and `dynamic-flows` packages. It reduces bundles sizes (in filesystem) as follows:

### `components`
- `es/no-polyfill`: `265kb` -> `242kb`
- `es/polyfill`: `274kb` -> `251kb`
- `umd/no-polyfill`: `341kb` -> `324kb`
- `umd/polyfill`: `382kb` -> `365kb`

### `dynamic-flows`
- `es/no-polyfill`: `126kb` -> `117kb`
- `es/polyfill`: `130kb` -> `120kb`

## 💬 Considerations <!-- additional info for reviewing (e.g links to Mockups, docs etc.), discussion topics -->
~~This only applies to functional components, class components which use `static` propTypes won't benefit from this~~. In the Google Chrome list it is flagged as "safe to use by default". ~~I didn't do any testing beyond symlinking locally and running storybook~~ I managed to get my tests running locally and fixed the failing test.

@andreapiras Apologies if this has become more effort than it's worth 😅 ~~now it doesn't apply the babel plugin to the `testConfig` envs in the babel files - is this okay? It means that the test environment deviates slightly from the production environments~~ the plugin applies to all builds, and the test referring to `propTypes` now uses `.props` (this also removed the ESLint warning for `forbid-foreign-prop-types`). It required a bit of faff in the test though as it needed to differentiate between a component selector and a wrapper, let me know if it's okay.

## ✅ Checklist

- [x] All changes are covered by tests
- [ ] All changes have been crossbrowser checked, especially IE11
- [ ] The changes are covered in docs