### PR TITLE
feat: add a layout service for converting dynamic flow steps without layouts to DynamicLayout format

### DIFF
--- a/packages/dynamic-flows/src/flow/layoutService/LayoutService.js
+++ b/packages/dynamic-flows/src/flow/layoutService/LayoutService.js
@@ -1,0 +1,176 @@
+function convertStepToLayout(step) {
+  switch (step.type) {
+    case 'final':
+      return convertFinalStepToDynamicLayout(step);
+    case 'decision':
+      return convertDecisionStepToDynamicLayout(step);
+    case 'form':
+      return convertFormStepToDynamicLayout(step);
+    default:
+      throw new Error('invalid step type');
+  }
+}
+
+function convertCommonComponents(step) {
+  const layout = [];
+
+  if (step.title) {
+    layout.push(convertStepTitleToDynamicHeading(step.title));
+  }
+  if (step.image) {
+    const image = convertStepImageToDynamicImage(step.image);
+    layout.push(dynamicBox([image]));
+  }
+  if (step.description) {
+    layout.push(convertStepDescriptionToDynamicParagraph(step.description));
+  }
+
+  return layout;
+}
+
+function convertFormStepToDynamicLayout(step) {
+  let layout = convertCommonComponents(step);
+
+  if (step.reviewFields) {
+    layout.push(convertStepReviewToDynamicReview(step.reviewFields));
+  }
+
+  if (step.schemas) {
+    layout = layout.concat(getSchemaLayout(step));
+  }
+
+  if (step.actions) {
+    const actions = step.actions.map(convertStepActionToDynamicAction);
+    layout.push(dynamicBox(actions, 'md'));
+  }
+
+  return layout;
+}
+
+function convertFinalStepToDynamicLayout(step) {
+  const layout = convertCommonComponents(step);
+
+  if (step.action) {
+    const actions = [convertStepActionToDynamicAction(step.action)];
+    layout.push(dynamicBox(actions, 'md'));
+  }
+
+  return layout;
+}
+
+function convertDecisionStepToDynamicLayout(step) {
+  const layout = convertCommonComponents(step);
+
+  if (step.options) {
+    layout.push(convertStepDecisionToDynamicDecision(step.options));
+  }
+
+  return layout;
+}
+
+function dynamicBox(components, size) {
+  return {
+    type: 'box',
+    width: size || 'sm',
+    components,
+  };
+}
+
+function convertStepTitleToDynamicHeading(title) {
+  return {
+    type: 'title',
+    text: title,
+    size: 'lg',
+    margin: 'lg',
+    align: 'center',
+  };
+}
+
+function convertStepDescriptionToDynamicParagraph(description) {
+  return {
+    type: 'paragraph',
+    text: description,
+    align: 'center',
+  };
+}
+
+function convertStepSchemaToDynamicForm(schema) {
+  return {
+    type: 'form',
+    schema,
+  };
+}
+
+function convertStepDecisionToDynamicDecision(options) {
+  return {
+    type: 'decision',
+    options: options.map(convertStepDecisionOption),
+  };
+}
+
+function convertStepDecisionOption(option) {
+  return {
+    text: option.title,
+    description: option.description,
+    action: {
+      method: 'GET',
+      url: option.url,
+      disabled: option.disabled,
+    },
+  };
+}
+
+function convertStepImageToDynamicImage(url) {
+  return {
+    type: 'image',
+    url,
+    margin: 'lg',
+  };
+}
+
+function convertStepActionToDynamicAction(action) {
+  return {
+    type: 'action',
+    context: action.type,
+    action: { ...action, type: undefined },
+  };
+}
+
+function convertStepReviewToDynamicReview(reviewFields) {
+  return {
+    type: 'review',
+    text: reviewFields.title,
+    definitions: reviewFields.fields.map(convertReviewFieldToDefinition),
+  };
+}
+
+function convertReviewFieldToDefinition(reviewField) {
+  return {
+    label: reviewField.title,
+    value: reviewField.value,
+  };
+}
+
+function getSchemaLayout(step) {
+  const layout = [];
+
+  if (step.schemas && step.schemas[0]) {
+    const schema = step.schemas[0];
+    const dynamicForm = convertStepSchemaToDynamicForm(schema);
+    if (isWideForm(schema)) {
+      layout.push(dynamicForm);
+    } else {
+      layout.push(dynamicBox([dynamicForm], 'md'));
+    }
+  }
+
+  return layout;
+}
+
+function isWideForm() {
+  // For the time being we won't support automatically widening forms
+  // Unlike it V2, there is no way to easily iterate and identify narrow fields
+  return false;
+}
+
+export { convertStepToLayout };

--- a/packages/dynamic-flows/src/flow/layoutService/LayoutService.js
+++ b/packages/dynamic-flows/src/flow/layoutService/LayoutService.js
@@ -94,10 +94,11 @@ function convertStepDescriptionToDynamicParagraph(description) {
   };
 }
 
-function convertStepSchemaToDynamicForm(schema) {
+function convertStepSchemaToDynamicForm(schema, model) {
   return {
     type: 'form',
     schema,
+    model,
   };
 }
 
@@ -156,7 +157,7 @@ function getSchemaLayout(step) {
 
   if (step.schemas && step.schemas[0]) {
     const schema = step.schemas[0];
-    const dynamicForm = convertStepSchemaToDynamicForm(schema);
+    const dynamicForm = convertStepSchemaToDynamicForm(schema, step.model);
     if (isWideForm(schema)) {
       layout.push(dynamicForm);
     } else {

--- a/packages/dynamic-flows/src/flow/layoutService/LayoutService.js
+++ b/packages/dynamic-flows/src/flow/layoutService/LayoutService.js
@@ -19,7 +19,7 @@ function convertCommonComponents(step) {
   }
   if (step.image) {
     const image = convertStepImageToDynamicImage(step.image);
-    layout.push(dynamicBox([image]));
+    layout.push(dynamicBox([image], 'sm'));
   }
   if (step.description) {
     layout.push(convertStepDescriptionToDynamicParagraph(step.description));
@@ -29,14 +29,14 @@ function convertCommonComponents(step) {
 }
 
 function convertFormStepToDynamicLayout(step) {
-  let layout = convertCommonComponents(step);
+  const layout = convertCommonComponents(step);
 
   if (step.reviewFields) {
     layout.push(convertStepReviewToDynamicReview(step.reviewFields));
   }
 
   if (step.schemas) {
-    layout = layout.concat(getSchemaLayout(step));
+    layout.push(...getSchemaLayout(step));
   }
 
   if (step.actions) {
@@ -71,7 +71,7 @@ function convertDecisionStepToDynamicLayout(step) {
 function dynamicBox(components, size) {
   return {
     type: 'box',
-    width: size || 'sm',
+    width: size || 'md',
     components,
   };
 }

--- a/packages/dynamic-flows/src/flow/layoutService/LayoutService.spec.js
+++ b/packages/dynamic-flows/src/flow/layoutService/LayoutService.spec.js
@@ -1,4 +1,4 @@
-import { convertStepToLayout } from './LayoutService';
+import { convertStepToLayout } from '.';
 
 describe('Given a utility service for handling dynamic layouts', () => {
   describe('when we receive a decision step', () => {

--- a/packages/dynamic-flows/src/flow/layoutService/LayoutService.spec.js
+++ b/packages/dynamic-flows/src/flow/layoutService/LayoutService.spec.js
@@ -209,6 +209,7 @@ describe('Given a utility service for handling dynamic layouts', () => {
             {
               type: 'form',
               schema,
+              model,
             },
           ],
         },

--- a/packages/dynamic-flows/src/flow/layoutService/LayoutService.spec.js
+++ b/packages/dynamic-flows/src/flow/layoutService/LayoutService.spec.js
@@ -1,0 +1,236 @@
+import { convertStepToLayout } from './LayoutService';
+
+describe('Given a utility service for handling dynamic layouts', () => {
+  describe('when we receive a decision step', () => {
+    it('should convert it into a layout', () => {
+      const option1 = {
+        title: 'Thing one',
+        description: 'The first type of thing',
+        url: 'https://...',
+      };
+
+      const option2 = {
+        title: 'Thing two',
+        url: 'https://...',
+        disabled: true,
+      };
+
+      const decisionStep = {
+        type: 'decision',
+        key: 'decide-thing-type',
+        title: 'Thing type',
+        description: 'Please choose between types of things',
+        options: [option1, option2],
+      };
+
+      const decisionLayout = [
+        {
+          type: 'title',
+          text: decisionStep.title,
+          size: 'lg',
+          margin: 'lg',
+          align: 'center',
+        },
+        {
+          type: 'paragraph',
+          text: decisionStep.description,
+          align: 'center',
+        },
+        {
+          type: 'decision',
+          options: [
+            {
+              text: option1.title,
+              description: option1.description,
+              action: {
+                method: 'GET',
+                url: option1.url,
+              },
+            },
+            {
+              text: option2.title,
+              action: {
+                method: 'GET',
+                url: option2.url,
+                disabled: true,
+              },
+            },
+          ],
+        },
+      ];
+
+      expect(convertStepToLayout(decisionStep)).toEqual(decisionLayout);
+    });
+  });
+
+  describe('when we receive a final step', () => {
+    it('should convert it into a layout', () => {
+      const exitAction = {
+        title: 'Exit',
+        type: 'success',
+        exit: true,
+        data: {
+          exitValue: 'value',
+        },
+      };
+
+      const finalStep = {
+        type: 'final',
+        key: 'thing-final',
+        title: 'We create the thing!',
+        description: 'You now do stuff with the thing',
+        image: '/images/1234.png',
+        success: true,
+        action: exitAction,
+      };
+
+      const finalLayout = [
+        {
+          type: 'title',
+          text: finalStep.title,
+          size: 'lg',
+          margin: 'lg',
+          align: 'center',
+        },
+        {
+          type: 'box',
+          width: 'sm',
+          components: [
+            {
+              type: 'image',
+              url: finalStep.image,
+              margin: 'lg',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          text: finalStep.description,
+          align: 'center',
+        },
+        {
+          type: 'box',
+          width: 'md',
+          components: [
+            {
+              type: 'action',
+              context: exitAction.type,
+              action: { ...exitAction, type: undefined },
+            },
+          ],
+        },
+      ];
+
+      expect(convertStepToLayout(finalStep)).toEqual(finalLayout);
+    });
+  });
+
+  describe('when we receive a form step', () => {
+    it('should convert it into a layout', () => {
+      const schema = {
+        id: 'thing',
+        type: 'object',
+        properties: {
+          a: {
+            type: 'integer',
+          },
+          b: {
+            type: 'string',
+          },
+        },
+      };
+
+      const submitAction = {
+        title: 'Submit',
+        type: 'primary',
+        url: '/things',
+        method: 'POST',
+      };
+
+      const cancelAction = {
+        title: 'Cancel',
+        type: 'delete',
+        exit: true,
+      };
+
+      const reviewFields = {
+        title: 'A thing',
+        fields: [
+          {
+            title: 'Label for a',
+            value: 'Value of a',
+          },
+        ],
+      };
+
+      const model = {
+        a: 1,
+      };
+
+      const formStep = {
+        type: 'form',
+        key: 'create-thing',
+        title: 'Step 1',
+        description: 'Please create a thing',
+        refreshFormUrl: '/thing-requirements',
+        actions: [submitAction, cancelAction],
+        reviewFields,
+        model,
+        schemas: [schema],
+      };
+
+      const finalLayout = [
+        {
+          type: 'title',
+          text: formStep.title,
+          size: 'lg',
+          margin: 'lg',
+          align: 'center',
+        },
+        {
+          type: 'paragraph',
+          text: formStep.description,
+          align: 'center',
+        },
+        {
+          type: 'review',
+          text: reviewFields.title,
+          definitions: [
+            {
+              label: reviewFields.fields[0].title,
+              value: reviewFields.fields[0].value,
+            },
+          ],
+        },
+        {
+          type: 'box',
+          width: 'md',
+          components: [
+            {
+              type: 'form',
+              schema,
+            },
+          ],
+        },
+        {
+          type: 'box',
+          width: 'md',
+          components: [
+            {
+              type: 'action',
+              context: submitAction.type,
+              action: { ...submitAction, type: undefined },
+            },
+            {
+              type: 'action',
+              context: cancelAction.type,
+              action: { ...cancelAction, type: undefined },
+            },
+          ],
+        },
+      ];
+
+      expect(convertStepToLayout(formStep)).toEqual(finalLayout);
+    });
+  });
+});

--- a/packages/dynamic-flows/src/flow/layoutService/index.js
+++ b/packages/dynamic-flows/src/flow/layoutService/index.js
@@ -1,0 +1,1 @@
+export { convertStepToLayout } from './LayoutService';


### PR DESCRIPTION
## 🖼 Context

Layout is not a required property of dynamic flow steps so we need to handle layout of two different approaches.  Rather than do this, we will simply map steps without layouts to layout format using a service.  From then on, we can treat all dynamic flow steps as layouts and we need only one approach for the layout of our template.

## 🚀 Changes

We add a service that maps three step types (form, decision & final) to a dynamic layout specification

## 🤔 Considerations

The DynamicFlow component that will use the service is yet to be written.

We do not mimic the logic from V2 that narrows/widens the form based on the width of the fields inside the form, as in V3, it is not straightforward to interrogate the fields. 

We do not convert "upload steps" into side by side layouts, as in V2.  The intent is to add a layout to the step to achieve these more complex layouts.

## ✅ Checklist

- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/master/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
