### PR TITLE
pass required field to validation

### DIFF
--- a/packages/dynamic-flows/src/common/validation/validation-failures/spec.js
+++ b/packages/dynamic-flows/src/common/validation/validation-failures/spec.js
@@ -46,6 +46,9 @@ describe('Given a library for identifying validation failures', () => {
     it('should return [type] when incorrect data type', () => {
       expect(getValidationFailures(1234, schema)).toEqual(['type']);
     });
+    it('should return only [required] when value is empty string and required', () => {
+      expect(getValidationFailures('', schema, true)).toEqual(['required']);
+    });
   });
 
   describe('when validating a string date', () => {

--- a/packages/dynamic-flows/src/field/Field.js
+++ b/packages/dynamic-flows/src/field/Field.js
@@ -30,8 +30,8 @@ const DefaultValidationMessages = {
   PATTERN: 'Incorrect format',
   MINLENGTH: 'The value is too short',
   MAXLENGTH: 'The value is too long',
-  MIN: 'The value is too low',
-  MAX: 'The value is too high',
+  MINIMUM: 'The value is too low',
+  MAXIMUM: 'The value is too high',
 };
 
 export default class Field extends Component {
@@ -133,8 +133,8 @@ export default class Field extends Component {
         pattern: Types.string,
         minlength: Types.string,
         maxlength: Types.string,
-        min: Types.string,
-        max: Types.string,
+        minimum: Types.string,
+        maximum: Types.string,
       }),
     }).isRequired,
 

--- a/packages/dynamic-flows/src/field/Field.js
+++ b/packages/dynamic-flows/src/field/Field.js
@@ -200,7 +200,7 @@ export default class Field extends Component {
   validateValue(newValue) {
     const validationFailures = {};
     const { field } = this.props;
-    const validationFailuresKeys = getValidationFailures(newValue, field);
+    const validationFailuresKeys = getValidationFailures(newValue, field, field.required);
     validationFailuresKeys.forEach((failure) => {
       const messageKey = failure.toLowerCase();
 

--- a/packages/dynamic-flows/src/field/Field.js
+++ b/packages/dynamic-flows/src/field/Field.js
@@ -30,8 +30,8 @@ const DefaultValidationMessages = {
   PATTERN: 'Incorrect format',
   MINLENGTH: 'The value is too short',
   MAXLENGTH: 'The value is too long',
-  MINIMUM: 'The value is too low',
-  MAXIMUM: 'The value is too high',
+  MIN: 'The value is too low',
+  MAX: 'The value is too high',
 };
 
 export default class Field extends Component {
@@ -133,8 +133,8 @@ export default class Field extends Component {
         pattern: Types.string,
         minlength: Types.string,
         maxlength: Types.string,
-        minimum: Types.string,
-        maximum: Types.string,
+        min: Types.string,
+        max: Types.string,
       }),
     }).isRequired,
 


### PR DESCRIPTION
## 🖼 Context
I am getting the minimum and maximum validation despite having the required field
<img width="488" alt="Screenshot 2020-08-26 at 3 43 59 PM" src="https://user-images.githubusercontent.com/51073572/91389208-7036b680-e86b-11ea-83be-53eeeb99b297.png">


## 🚀 Changes

Pass in the required field to do the check in `getValidationFailures`

## 🤔 Considerations

This fixes the minimum and maximum showing up on the required fields, but I think something is inserting the `minimum` and `maximum` in the schema, so it might still trigger on a non-required field

There seems to be a lot of code duplication between this and styleguide-components. Could one just depend on the other instead?

## ✅ Checklist

- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
