### PR TITLE
fix: apply overflow hidden to content container

### DIFF
--- a/packages/components/src/card/Card.js
+++ b/packages/components/src/card/Card.js
@@ -50,7 +50,7 @@ const Card = ({
         />
       </div>
       {isOpen && (
-        <div className="p-l-panel p-r-panel p-b-panel">
+        <div className="p-l-panel p-r-panel p-b-panel tw-card__content">
           <div className="media">
             <div className="media-left">
               <div className="circle circle-sm circle-inverse circle-responsive invisible" />

--- a/packages/components/src/card/Card.less
+++ b/packages/components/src/card/Card.less
@@ -32,4 +32,10 @@
       }
     }
   }
+
+  &__content {
+    .media-body {
+      overflow: hidden;
+    }
+  }
 }


### PR DESCRIPTION
## 🖼 Context

When nesting tabs inside cards, the tabs overflowed when transitioning between tabs. This fix prevents that.

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
