### PR TITLE
chore: add hold build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,17 +187,6 @@ workflows:
                 - gh-pages
                 - main
 
-      - deploy-docs-for-branch:
-          type: approval
-          context: frontend-build
-          requires:
-            - setup
-          filters:
-            branches:
-              ignore:
-                - gh-pages
-                - main
-
       - deploy-docs:
           context: frontend-build
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,26 @@ workflows:
               only:
                 - main
 
+      - hold:
+        type: approval
+        requires:
+          - setup
+        filters:
+          branches:
+            ignore:
+              - gh-pages
+              - main
+
+      - deploy-docs-for-branch:
+          context: frontend-build
+          requires:
+            - hold
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+                - main
+
       - deploy-docs-for-branch:
           type: approval
           context: frontend-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,14 +168,14 @@ workflows:
                 - main
 
       - hold:
-        type: approval
-        requires:
-          - setup
-        filters:
-          branches:
-            ignore:
-              - gh-pages
-              - main
+          type: approval
+          requires:
+            - setup
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+                - main
 
       - deploy-docs-for-branch:
           context: frontend-build


### PR DESCRIPTION
## 🖼 Context

<!-- Why is this PR necessary? Please include links to mockups, JIRA ticket or other relevant documentation. -->
CircleCi is not running on the actually job of type approval but it has to be used (according to this [example](https://circleci.com/docs/2.0/workflows/#holding-a-workflow-for-a-manual-approval)) to unlock the dependant jobs

## 🚀 Changes

 <!-- What changes have you made? -->

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
