### PR TITLE
[WIP] Deprecation strategy update

### DIFF
--- a/rfc/0003-deprecation-strategy-and-higher-order-component.md
+++ b/rfc/0003-deprecation-strategy-and-higher-order-component.md
@@ -52,7 +52,7 @@ const Button = ({ label }) => <button>{label}</button>
 - add the new prop `children` and default its value to old one `label`.
 
 ```js
-const Button = ({ children = label, label  }) => <button>{children}</button>
+const Button = ({ label, children = label }) => <button>{children}</button>
 
 ```
 This solution is back-compatible and if `children` is not provided it will default to `label`.
@@ -61,7 +61,7 @@ To achieve #2, we will:
  - add a customProp deprecate function that will throw a warn message for the deprecated prop, including the `expire date`
 
 ```js
-const Button = ({ children = label, label  }) => <button>{children}</button>
+const Button = ({ label, children = label }) => <button>{children}</button>
 
 Button.propTypes = {
   // eslint-disable-next-line react/require-default-props


### PR DESCRIPTION
## 🖼 Context

We need to introduce a simpler deprecation strategy that allows us to move faster and create the smallest amount of tech debt as possible. Our aim is to deprecate a prop and still leave a window of time to allow consumer to upgrade the library version to adhere to the new API.

## 🚀 Changes

 <!-- What changes have you made? -->
- Update RFC
- Introduced the idea of args defaultValue assignments
- Introduced the `deprecated` function

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
