### PR TITLE
fix: don't display completed until processing step is complete

### DIFF
--- a/packages/components/src/upload/steps/processingStep/processingStep.js
+++ b/packages/components/src/upload/steps/processingStep/processingStep.js
@@ -33,9 +33,9 @@ const ProcessingStep = (props) => {
           onAnimationCompleted={(status) => onAnimationCompleted(status)}
         />
         <h4 className="m-t-3 m-b-3">
-          {!isSuccess && !isError && isProcessing && psProcessingText}
-          {isSuccess && psSuccessText}
-          {isError && psFailureText}
+          {isProcessing && psProcessingText}
+          {isSuccess && !isProcessing && psSuccessText}
+          {isError && !isProcessing && psFailureText}
         </h4>
         {psButtonText && (
           <button type="button" className="btn btn-default btn-sm" onClick={(e) => onClear(e)}>

--- a/packages/components/src/upload/steps/processingStep/processingStep.spec.js
+++ b/packages/components/src/upload/steps/processingStep/processingStep.spec.js
@@ -44,14 +44,14 @@ describe('ProcessingStep', () => {
     expect(component.find('h4').text()).toBe(PROCESSING_STEP_PROPS.psProcessingText);
   });
 
-  it('renders psSuccessText if isSuccess is true', () => {
+  it('renders psProcessingText if isSuccess is true but we are still processing', () => {
     component = shallow(<ProcessingStep {...PROCESSING_STEP_PROPS} isSuccess />);
-    expect(component.find('h4').text()).toBe(PROCESSING_STEP_PROPS.psSuccessText);
+    expect(component.find('h4').text()).toBe(PROCESSING_STEP_PROPS.psProcessingText);
   });
 
-  it('renders psFailureText if isError is true', () => {
+  it('renders psProcessingText if isError is true but we are still processing', () => {
     component = shallow(<ProcessingStep {...PROCESSING_STEP_PROPS} isError />);
-    expect(component.find('h4').text()).toBe(PROCESSING_STEP_PROPS.psFailureText);
+    expect(component.find('h4').text()).toBe(PROCESSING_STEP_PROPS.psProcessingText);
   });
 
   it('renders button when psButtonText is set up', () => {


### PR DESCRIPTION
## 🖼 Context

Potential alternative fix for the upload bug described [here](https://github.com/transferwise/neptune-web/pull/729).

## ✅ Checklist

- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
