### PR TITLE
fix: fix bug in MoneyInput component

### DIFF
--- a/packages/components/src/select/Select.js
+++ b/packages/components/src/select/Select.js
@@ -270,7 +270,8 @@ export default class Select extends Component {
     document.removeEventListener('click', this.handleDocumentClick, false);
   }
 
-  handleButtonClick = () => {
+  handleButtonClick = (e) => {
+    stopPropagation(e);
     if (!this.props.disabled) {
       this.open();
     }


### PR DESCRIPTION
Fixes #752

Stopping the propagation of this event to prevent bubbling seems to do the trick. 