### PR TITLE
feat: Use default value in OneOf const schemas

### DIFF
--- a/packages/dynamic-flows/src/jsonSchemaForm/oneOfSchema/OneOfSchema.spec.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/oneOfSchema/OneOfSchema.spec.js
@@ -119,11 +119,75 @@ describe('Given a oneOfSchema component', () => {
     });
 
     describe('when no model is present', () => {
-      it('should not render a generic schema', () => {
-        component = shallow(<OneOfSchema {...props} model={{}} />);
-        genericSchema = component.find(GenericSchema);
+      describe('and children schemas are non-const', () => {
+        it('should not render a generic schema', () => {
+          component = shallow(<OneOfSchema {...props} model={{}} />);
+          genericSchema = component.find(GenericSchema);
 
-        expect(genericSchema.length).toBe(0);
+          expect(genericSchema.length).toBe(0);
+        });
+      });
+
+      describe('and children schemas are const', () => {
+        const currencySchema = {
+          title: 'Currency',
+          type: 'string',
+          oneOf: [
+            { title: 'EUR', icon: { name: 'flag-eur' }, description: 'Euro', const: 'EUR' },
+            {
+              title: 'GBP',
+              icon: { name: 'flag-gbp' },
+              description: 'British pound',
+              const: 'GBP',
+            },
+            {
+              title: 'USD',
+              icon: { name: 'flag-usd' },
+              description: 'United States dollar',
+              const: 'USD',
+            },
+            {
+              title: 'ARS',
+              icon: { name: 'flag-ars' },
+              description: 'Argentine peso',
+              const: 'ARS',
+            },
+            {
+              title: 'AUD',
+              icon: { name: 'flag-aud' },
+              description: 'Australian dollar',
+              const: 'AUD',
+            },
+          ],
+          validationMessages: { required: 'Please enter currency.' },
+          refreshFormOnChange: true,
+          default: 'USD',
+        };
+
+        const defaultIndex = currencySchema.oneOf.findIndex(
+          (childSchema) => childSchema.const === currencySchema.default,
+        );
+
+        describe('and there is a valid default value', () => {
+          it('renders a SchemaFormControl with a value as expected', () => {
+            component = shallow(<OneOfSchema {...props} schema={currencySchema} model={{}} />);
+            const control = component.find(SchemaFormControl);
+            expect(control.prop('value')).toBe(defaultIndex);
+          });
+        });
+        describe('and there is no valid default value', () => {
+          it('renders a SchemaFormControl with a value of null  ', () => {
+            component = shallow(
+              <OneOfSchema
+                {...props}
+                schema={{ ...currencySchema, default: 'BANANA' }}
+                model={{}}
+              />,
+            );
+            const control = component.find(SchemaFormControl);
+            expect(control.prop('value')).toBe(null);
+          });
+        });
       });
     });
 


### PR DESCRIPTION
## 🖼 Context

The default value for const schemas within a `OneOf` was not being used.

Consider the following schema where the default value is "EUR":

```json
{
  "type": "object",
  "displayOrder": ["currency"],
  "properties": {
    "currency": {
      "title": "Currency",
      "type": "string",
      "oneOf": [
        { "title": "EUR", "icon": { "name": "flag-eur" }, "description": "Euro", "const": "EUR" },
        {
          "title": "GBP",
          "icon": { "name": "flag-gbp" },
          "description": "British pound",
          "const": "GBP"
        },
        {
          "title": "USD",
          "icon": { "name": "flag-usd" },
          "description": "United States dollar",
          "const": "USD"
        },
        {
          "title": "ARS",
          "icon": { "name": "flag-ars" },
          "description": "Argentine peso",
          "const": "ARS"
        },
        {
          "title": "AUD",
          "icon": { "name": "flag-aud" },
          "description": "Australian dollar",
          "const": "AUD"
        }
      ],
      "validationMessages": { "required": "Please enter currency." },
      "refreshFormOnChange": true,
      "default": "EUR"
    }
  },
  "required": ["currency"]
}
```
When this schema is used in a `JsonSchemaForm` without a model, the drop down does not pre-select the default value:

![Screenshot 2021-01-29 at 17 18 30](https://user-images.githubusercontent.com/67635620/106308212-49384280-6258-11eb-9fae-9ae9832899b6.png)

## 🚀 Changes

We now use the default value when there's no model and the child-schemas are const.

![Screenshot 2021-01-29 at 17 18 35](https://user-images.githubusercontent.com/67635620/106308367-81d81c00-6258-11eb-8847-6fab40c80419.png)

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
