### PR TITLE
feat: Display oneOf const when only 1 option

### DIFF
--- a/packages/dynamic-flows/src/jsonSchemaForm/oneOfSchema/OneOfSchema.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/oneOfSchema/OneOfSchema.js
@@ -154,7 +154,7 @@ const OneOfSchema = (props) => {
 
   return (
     <>
-      {props.schema.oneOf.length > 1 && (
+      {(props.schema.oneOf.length > 1 || isConstSchema(props.schema.oneOf[0])) && (
         <>
           <div className={classNames(formGroupClasses)}>
             {props.schema.title && (

--- a/packages/dynamic-flows/src/jsonSchemaForm/oneOfSchema/OneOfSchema.spec.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/oneOfSchema/OneOfSchema.spec.js
@@ -368,6 +368,27 @@ describe('Given a oneOfSchema component', () => {
       expect(controlFeedback.prop('errors')).toBe(null);
     });
 
+    describe('when one option is supplied', () => {
+      beforeEach(() => {
+        schema = {
+          title: 'Choose schema',
+          oneOf: [
+            {
+              title: 'One',
+              const: 1,
+            },
+          ],
+        };
+
+        props = { ...props, schema };
+        component = shallow(<OneOfSchema {...props} />);
+      });
+
+      it('should render a SchemaFormControl', () => {
+        expect(component.find(SchemaFormControl)).toHaveLength(1);
+      });
+    });
+
     describe('when the user changes schema', () => {
       beforeEach(() => {
         // SchemaFormControl broadcasts the INDEX(1) of the schema


### PR DESCRIPTION
## 🖼 Context

<!-- Why is this PR necessary? Please include links to mockups, JIRA ticket or other relevant documentation. -->
![Screenshot 2021-02-02 at 16 37 45](https://user-images.githubusercontent.com/55701870/106631790-01c1f700-6575-11eb-8cd8-a226c5f3d0c5.png)

When we have a single option in an oneOf of consts, we want to display it.

## 🚀 Changes

 <!-- What changes have you made? -->

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [X] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [X] Changes are tested and all tests pass
- [X] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [X] Changes work in all supported browsers (don't forget IE11)
- [X] You've updated the documentation if necessary
