### PR TITLE
fix: fix logic for mobile flag

### DIFF
--- a/packages/components/src/flowNavigation/FlowNavigation.js
+++ b/packages/components/src/flowNavigation/FlowNavigation.js
@@ -26,28 +26,31 @@ const FlowNavigation = ({ activeStep, avatar, logo, onClose, onGoBack, done, ste
 
   const newAvatar = done ? null : avatar;
 
-  const getLeftContentSmall = () => (
-    <div className="visible-xs">
-      {onGoBack && activeStep > 0 && (
-        <BackButton
-          label={
-            <AnimatedLabel
-              className="m-x-1"
-              labels={steps.map((step) => step.label)}
-              activeLabel={activeStep}
-            />
-          }
-          onClick={onGoBack}
+  const getLeftContentSmall = () => {
+    const displayGoBack = onGoBack && activeStep > 0;
+    return (
+      <div className="visible-xs">
+        {displayGoBack && (
+          <BackButton
+            label={
+              <AnimatedLabel
+                className="m-x-1"
+                labels={steps.map((step) => step.label)}
+                activeLabel={activeStep}
+              />
+            }
+            onClick={onGoBack}
+          />
+        )}
+        <div
+          className={classNames('np-flow-navigation--flag', {
+            'np-flow-navigation--flag__hidden': displayGoBack,
+            'np-flow-navigation--flag__display': !displayGoBack,
+          })}
         />
-      )}
-      <div
-        className={classNames('np-flow-navigation--flag', {
-          'np-flow-navigation--flag__hidden': activeStep,
-          'np-flow-navigation--flag__display': !activeStep,
-        })}
-      />
-    </div>
-  );
+      </div>
+    );
+  };
 
   return (
     <div

--- a/packages/components/src/flowNavigation/FlowNavigation.spec.js
+++ b/packages/components/src/flowNavigation/FlowNavigation.spec.js
@@ -137,17 +137,23 @@ describe('FlowNavigation', () => {
       expect(render(<FlowNavigation {...props} />).container).toMatchSnapshot();
     });
 
-    it(`renders logo mobile if onGoBack is not provided and activeStep = 0`, () => {
-      const { container, rerender } = render(<FlowNavigation {...props} />);
+    it(`renders flag if activeStep <= 0 onGoBack or is not provided`, () => {
+      const { container, rerender } = render(
+        <FlowNavigation {...props} activeStep={0} onGoBack={undefined} />,
+      );
 
       const flag = container.querySelector('.np-flow-navigation--flag');
 
       expect(flag.parentElement).toHaveClass('visible-xs');
       expect(flag).toHaveClass('np-flow-navigation--flag__display');
 
-      rerender(<FlowNavigation {...props} activeStep={1} />);
+      rerender(<FlowNavigation {...props} activeStep={1} onGoBack={undefined} />);
 
-      expect(flag.parentElement).toHaveClass('visible-xs');
+      expect(flag).toHaveClass('np-flow-navigation--flag__display');
+
+      rerender(<FlowNavigation {...props} activeStep={0} onGoBack={jest.fn()} />);
+
+      expect(flag).toHaveClass('np-flow-navigation--flag__display');
 
       rerender(<FlowNavigation {...props} onGoBack={jest.fn()} activeStep={1} />);
 


### PR DESCRIPTION
## 🖼 Context

The old logic showed the fast flag on mobile when onGoBack was undefined. The new logic shows the fast flag on mobile when there’s no activeStep number passed in. In send-flow we have steps that you can’t go back from (i.e. the payment step) so we pass in onGoBack={undefined}. Since we only show the back button when onGoBack is defined, and don’t show the flag when there’s an activeStep, we end up showing nothing.
## 🚀 Changes

 <!-- What changes have you made? -->
Update logic for onGoBack

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
