### PR TITLE
fix: removed old caret rotation

### DIFF
--- a/packages/css/src/less/components/_component-animations.less
+++ b/packages/css/src/less/components/_component-animations.less
@@ -40,8 +40,4 @@
   &:focus {
     text-decoration: none;
   }
-  &[aria-expanded='false'],
-  &.collapsed {
-    transform: rotate(-90deg);
-  }
 }


### PR DESCRIPTION

## 🖼 Context
Component animation previously applied to caret only are now being applied more widely, causing wrong behaviours:

![Screenshot 2021-02-09 at 12 03 09](https://user-images.githubusercontent.com/16908937/107377193-9a5ef680-6ae2-11eb-8ca3-2d7b9bfccc2b.png)

## 🚀 Changes

 <!-- What changes have you made? -->
Removed caret animation rotation introduced [here](https://github.com/transferwise/neptune-web/commit/3cef1b73411d0cbb2d6f9900d63b493850da5adb#diff-bdced92fb5ee360b987e3255e2a3a7a1410961eacb7340e44a070083e23f6fb3R44)

## 🤔 Considerations
This can have a wider impact but because it seems to have been introduced for caret only (which are not used anymore) we are confident that it won't affect anything else

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
