### PR TITLE
docs: remove duplicate width property for logo

### DIFF
--- a/packages/docs/liveEditorCode/flowNavigation.code.js
+++ b/packages/docs/liveEditorCode/flowNavigation.code.js
@@ -16,7 +16,6 @@
           alt="logo"
           src="./../../static/assets/img/wise_logo.svg"
           width="138"
-          width="138"
           height="24"
         />
       }


### PR DESCRIPTION
## 🚀 Changes

 <!-- What changes have you made? -->
- updated doc example to remove duplicate width property
## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
