### PR TITLE
feat: add ariaContent prop to Popover

### DIFF
--- a/packages/components/src/popover/Popover.js
+++ b/packages/components/src/popover/Popover.js
@@ -8,7 +8,7 @@ import { logActionRequiredIf } from '../utilities';
 
 import './Popover.css';
 
-const Popover = ({ children, className, content, preferredPlacement, title }) => {
+const Popover = ({ children, className, ariaContent, content, preferredPlacement, title }) => {
   logActionRequired({ preferredPlacement });
   const anchorRef = useRef(null);
   const [open, setOpen] = useState(false);
@@ -29,7 +29,7 @@ const Popover = ({ children, className, content, preferredPlacement, title }) =>
         {open && (
           <span role="status" className="sr-only">
             {title}
-            {content}
+            {ariaContent || content}
           </span>
         )}
       </span>
@@ -70,6 +70,7 @@ Popover.Placement = {
 
 Popover.defaultProps = {
   className: undefined,
+  ariaContent: undefined,
   preferredPlacement: Popover.Placement.RIGHT,
   title: undefined,
 };
@@ -78,6 +79,7 @@ Popover.propTypes = {
   children: Types.node.isRequired,
   className: Types.string,
   content: Types.node.isRequired,
+  ariaContent: Types.string,
   /** @DEPRECATED LEFT_TOP/RIGHT_TOP use TOP instead, @DEPRECATED BOTTOM_RIGHT/BOTTOM_LEFT use BOTTOM instead */
   preferredPlacement: Types.oneOf([
     Popover.Placement.TOP,

--- a/packages/components/src/popover/Popover.spec.js
+++ b/packages/components/src/popover/Popover.spec.js
@@ -100,7 +100,7 @@ describe('Popover', () => {
       expect(getPanel()).not.toBeInTheDocument();
     });
 
-    it('renders role status for assistive technologies readers', async () => {
+    it('renders role status for assistive technologies readers with content', async () => {
       await waitFor(() => {
         render(
           <Popover {...props}>
@@ -117,6 +117,24 @@ describe('Popover', () => {
       expect(screen.getByRole('status').innerHTML).toBe(`${props.title}${props.content}`);
       expect(screen.getByRole('status')).toHaveClass('sr-only');
     });
+  });
+
+  it('renders role status for assistive technologies readers with aria content', async () => {
+    await waitFor(() => {
+      render(
+        <Popover ariaContent="ariaContent" {...props}>
+          <button type="button">Open</button>
+        </Popover>,
+      );
+    });
+
+    expect(screen.queryByRole('status')).toBeNull();
+
+    fireEvent.click(getTrigger());
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByRole('status').innerHTML).toBe(`${props.title}ariaContent`);
+    expect(screen.getByRole('status')).toHaveClass('sr-only');
   });
 
   describe('on mobile', () => {


### PR DESCRIPTION
## 🖼 Context
[DS-978](https://transferwise.atlassian.net/browse/DS-978)

In our use-case, when passing a focusable content to the component, it causes assistive technologies to focus it twice. Also the contents are very visual, so plainly reading them would not work well.

## 🚀 Changes

- Provide an ariaContent prop as a descriptor in case Popover contains an illustration, or any other content that would otherwise require further description for screen readers.

## 🤔 Considerations

- Tried with `aria-content`, but eslint complains `content` is not a valid aria attribute.

![Kitten](https://i.imgur.com/yJm9Fhy.gif)

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
