### PR TITLE
fix: wrap accordion onClick

### DIFF
--- a/packages/components/src/accordion/Accordion.js
+++ b/packages/components/src/accordion/Accordion.js
@@ -15,14 +15,16 @@ const Accordion = ({ items, onClick, indexOpen }) => {
     setItemsOpen(newItems);
   };
 
-  return items.map((item, index) => (
-    <AccordionItem
-      key={item.id || index}
-      onClick={() => handleOnClick(index)}
-      open={itemsOpen[index]}
-      {...item}
-    />
-  ));
+  return items.map((item, index) => {
+    return (
+      <AccordionItem
+        key={item.id || index}
+        open={itemsOpen[index]}
+        {...item}
+        onClick={() => handleOnClick(index)}
+      />
+    );
+  });
 };
 
 Accordion.propTypes = {

--- a/packages/components/src/accordion/Accordion.spec.js
+++ b/packages/components/src/accordion/Accordion.spec.js
@@ -50,11 +50,14 @@ describe('Accordion', () => {
 
   describe('open and close', () => {
     it('opens an item when clicked', () => {
-      const { getAllByRole, container } = render(<Accordion items={items} />);
+      const onClick = jest.fn();
+      const { getAllByRole, container } = render(<Accordion items={items} onClick={onClick} />);
       userEvent.click(getAllByRole('button')[0]);
 
       expect(container).toMatchSnapshot();
       expect(container.querySelectorAll('.closed')).toHaveLength(2);
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(onClick).toHaveBeenCalledWith(0);
     });
   });
 

--- a/packages/components/src/accordion/Accordion.story.js
+++ b/packages/components/src/accordion/Accordion.story.js
@@ -16,6 +16,7 @@ export const basic = () => {
       content:
         'Lauri Ipsum is simply dummy text of the printing and typesetting industry. Lauri Ipsum has been the industry ever since the 1500s, when',
       id: 'Item 1',
+      onClick: (index) => console.log('ok', index),
     },
     {
       title: 'Item 2',


### PR DESCRIPTION
## 🖼 Context

<!-- Why is this PR necessary? Please include links to mockups, JIRA ticket or other relevant documentation. -->
onClick handler in accordion is being overwritten by the prop passed in by the user. This is stopping the accordion item being opened and closed

## 🚀 Changes

 <!-- What changes have you made? -->
- onClick wrapped by accordion takes precendence over the onClick specified in accordion props when passed to accordionitem

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
