### PR TITLE
fix: reintroduced Panel animation

### DIFF
--- a/packages/components/src/common/hooks/useClientWidth/useClientWidth.spec.js
+++ b/packages/components/src/common/hooks/useClientWidth/useClientWidth.spec.js
@@ -6,12 +6,6 @@ import { useClientWidth } from './useClientWidth';
 jest.mock('lodash.throttle', () => jest.fn((fn) => fn));
 
 describe('useClientWidth', () => {
-  beforeEach(() => {
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => cb());
-  });
-  afterAll(() => {
-    window.requestAnimationFrame.mockRestore();
-  });
   describe('when invalid ref is provided', () => {
     it('returns 0', () => {
       const ref = { invalid: true };

--- a/packages/components/src/common/panel/Panel.js
+++ b/packages/components/src/common/panel/Panel.js
@@ -1,7 +1,8 @@
 import React, { useState, forwardRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
+import classNames from 'classnames';
 import { usePopper } from 'react-popper';
+import CSSTransition from 'react-transition-group/CSSTransition';
 
 import { Position } from '..';
 import './Panel.css';
@@ -65,20 +66,29 @@ const Panel = forwardRef(
     // Popper recommends to use the popper element as a wrapper around an inner element that can have any CSS property transitioned for animations.
 
     return (
-      open && (
+      <CSSTransition
+        in={open}
+        appear
+        // Wait for animation to finish before unmount.
+        timeout={{ enter: 0, exit: 350 }}
+        classNames={{
+          enterDone: classNames({ 'np-panel--open': open }),
+        }}
+        unmountOnExit
+      >
         <FocusBoundary onClose={handleOnClose}>
           <div
             ref={setPopperElement}
             style={{ ...styles.popper }}
             {...attributes.popper}
-            className={classnames('np-panel', { 'np-panel--open': open }, className)}
+            className={classNames('np-panel', className)}
           >
-            <div ref={ref} className={classnames('np-panel__content')}>
+            <div ref={ref} className={classNames('np-panel__content')}>
               {children}
               {/* Arrow has to stay inside content to get the same animations as the "dialog" and to get hidden when panel is closed. */}
               {arrow && (
                 <div
-                  className={classnames('np-panel__arrow')}
+                  className={classNames('np-panel__arrow')}
                   ref={setArrowElement}
                   style={styles.arrow}
                 />
@@ -86,7 +96,7 @@ const Panel = forwardRef(
             </div>
           </div>
         </FocusBoundary>
-      )
+      </CSSTransition>
     );
   },
 );

--- a/packages/components/src/common/panel/Panel.js
+++ b/packages/components/src/common/panel/Panel.js
@@ -1,6 +1,6 @@
 import React, { useState, forwardRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import { usePopper } from 'react-popper';
 import CSSTransition from 'react-transition-group/CSSTransition';
 
@@ -81,14 +81,14 @@ const Panel = forwardRef(
             ref={setPopperElement}
             style={{ ...styles.popper }}
             {...attributes.popper}
-            className={classNames('np-panel', className)}
+            className={classnames('np-panel', className)}
           >
-            <div ref={ref} className={classNames('np-panel__content')}>
+            <div ref={ref} className={classnames('np-panel__content')}>
               {children}
               {/* Arrow has to stay inside content to get the same animations as the "dialog" and to get hidden when panel is closed. */}
               {arrow && (
                 <div
-                  className={classNames('np-panel__arrow')}
+                  className={classnames('np-panel__arrow')}
                   ref={setArrowElement}
                   style={styles.arrow}
                 />

--- a/packages/components/src/common/panel/Panel.js
+++ b/packages/components/src/common/panel/Panel.js
@@ -70,9 +70,9 @@ const Panel = forwardRef(
         in={open}
         appear
         // Wait for animation to finish before unmount.
-        timeout={{ enter: 0, exit: 350 }}
+        timeout={{ enter: 0, exit: 150 }}
         classNames={{
-          enterDone: classNames({ 'np-panel--open': open }),
+          enterDone: 'np-panel--open',
         }}
         unmountOnExit
       >

--- a/packages/components/src/common/panel/Panel.spec.js
+++ b/packages/components/src/common/panel/Panel.spec.js
@@ -2,6 +2,11 @@ import React from 'react';
 import { render } from '../../test-utils';
 import Panel from './Panel';
 
+jest.mock(
+  'react-transition-group/CSSTransition',
+  () => (props) => (props.in ? <div className="np-panel--open">{props.children}</div> : null), // eslint-disable-line
+);
+
 describe('Panel', () => {
   const props = {
     arrow: true,

--- a/packages/components/src/common/panel/__snapshots__/Panel.spec.js.snap
+++ b/packages/components/src/common/panel/__snapshots__/Panel.spec.js.snap
@@ -2,25 +2,29 @@
 
 exports[`Panel renders 1`] = `
 <div>
-  <span
-    class="np-focus-boundary d-inline-block outline-none"
-    tabindex="-1"
+  <div
+    class="np-panel--open"
   >
-    <div
-      class="np-panel np-panel--open"
-      style="position: absolute; left: 0px; top: 0px;"
+    <span
+      class="np-focus-boundary d-inline-block outline-none"
+      tabindex="-1"
     >
       <div
-        class="np-panel__content"
+        class="np-panel"
+        style="position: absolute; left: 0px; top: 0px;"
       >
-        <div>
-          children
-        </div>
         <div
-          class="np-panel__arrow"
-        />
+          class="np-panel__content"
+        >
+          <div>
+            children
+          </div>
+          <div
+            class="np-panel__arrow"
+          />
+        </div>
       </div>
-    </div>
-  </span>
+    </span>
+  </div>
 </div>
 `;

--- a/packages/components/src/common/responsivePanel/ResponsivePanel.spec.js
+++ b/packages/components/src/common/responsivePanel/ResponsivePanel.spec.js
@@ -43,12 +43,7 @@ describe('ResponsivePanel', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-  beforeEach(() => {
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => cb());
-  });
-  afterAll(() => {
-    window.requestAnimationFrame.mockRestore();
-  });
+
   let container;
 
   describe('on desktop', () => {

--- a/packages/components/src/decision/Decision.spec.js
+++ b/packages/components/src/decision/Decision.spec.js
@@ -36,13 +36,11 @@ describe('Decision', () => {
 
   afterAll(() => {
     Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
-    window.requestAnimationFrame.mockRestore();
   });
 
   let container;
   beforeEach(() => {
     resetClientWidth(Breakpoint.EXTRA_SMALL - 1);
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => cb());
   });
 
   describe(`when presentation is ${DecisionPresentation.LIST_BLOCK}`, () => {

--- a/packages/components/src/flowNavigation/FlowNavigation.spec.js
+++ b/packages/components/src/flowNavigation/FlowNavigation.spec.js
@@ -33,12 +33,10 @@ describe('FlowNavigation', () => {
   };
   beforeEach(() => {
     resetClientWidth(Breakpoint.LARGE + 1);
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => cb());
   });
 
   afterAll(() => {
     Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
-    window.requestAnimationFrame.mockRestore();
   });
 
   const props = {

--- a/packages/components/src/info/Info.spec.js
+++ b/packages/components/src/info/Info.spec.js
@@ -11,14 +11,6 @@ describe('Info', () => {
     'aria-label': 'aria-label',
   };
 
-  beforeAll(() => {
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => cb());
-  });
-
-  afterAll(() => {
-    window.requestAnimationFrame.mockRestore();
-  });
-
   it('renders small icon', async () => {
     await waitFor(() => {
       render(<Info {...props} />);

--- a/packages/components/src/popover/Popover.spec.js
+++ b/packages/components/src/popover/Popover.spec.js
@@ -3,6 +3,11 @@ import { fireEvent, render, waitFor, screen } from '../test-utils';
 import Popover from './Popover';
 import { Breakpoint, Position } from '../common';
 
+jest.mock(
+  'react-transition-group/CSSTransition',
+  () => (props) => (props.in ? <div className="np-panel--open">{props.children}</div> : null), // eslint-disable-line
+);
+
 describe('Popover', () => {
   const props = {
     arrow: true,

--- a/packages/components/src/popover/__snapshots__/Popover.spec.js.snap
+++ b/packages/components/src/popover/__snapshots__/Popover.spec.js.snap
@@ -18,41 +18,45 @@ exports[`Popover on desktop renders when is open 1`] = `
       class="np-size-swapper d-inline-flex"
       style="visibility: visible;"
     >
-      <span
-        class="np-focus-boundary d-inline-block outline-none"
-        tabindex="-1"
+      <div
+        class="np-panel--open"
       >
-        <div
-          class="np-panel np-panel--open np-popover__container"
-          data-popper-escaped="true"
-          data-popper-placement="right"
-          data-popper-reference-hidden="true"
-          style="position: absolute; left: 0px; top: 0px; transform: translate(16px, 0px);"
+        <span
+          class="np-focus-boundary d-inline-block outline-none"
+          tabindex="-1"
         >
           <div
-            class="np-panel__content"
+            class="np-panel np-popover__container"
+            data-popper-escaped="true"
+            data-popper-placement="right"
+            data-popper-reference-hidden="true"
+            style="position: absolute; left: 0px; top: 0px; transform: translate(16px, 0px);"
           >
             <div
-              aria-hidden="false"
-              class="np-popover__content"
-              role="tooltip"
+              class="np-panel__content"
             >
               <div
-                aria-level="1"
-                class="np-popover__title m-b-1"
-                role="heading"
+                aria-hidden="false"
+                class="np-popover__content"
+                role="tooltip"
               >
-                title
+                <div
+                  aria-level="1"
+                  class="np-popover__title m-b-1"
+                  role="heading"
+                >
+                  title
+                </div>
+                content
               </div>
-              content
+              <div
+                class="np-panel__arrow"
+                style="position: absolute; top: 0px; transform: translate(0px, 0px);"
+              />
             </div>
-            <div
-              class="np-panel__arrow"
-              style="position: absolute; top: 0px; transform: translate(0px, 0px);"
-            />
           </div>
-        </div>
-      </span>
+        </span>
+      </div>
     </div>
   </span>
 </div>

--- a/packages/test-config/config/setupTests.js
+++ b/packages/test-config/config/setupTests.js
@@ -5,6 +5,8 @@ const Adapter = require('enzyme-adapter-react-16');
 global.fetch = require('jest-fetch-mock');
 enzyme.configure({ adapter: new Adapter() });
 
+global.requestAnimationFrame = (cb) => cb();
+
 // https://github.com/esphen/jest-prop-type-error/blob/master/index.js
 // This mock will make tests fail when props error occurs.
 const { error } = console;
@@ -15,4 +17,5 @@ console.error = (message, ...args) => {
 
   error.apply(console, [message, ...args]);
 };
+
 /* eslint-enable */


### PR DESCRIPTION
## 🖼 Context

- Reintroduced panel animation accidntally removed

## 🚀 Changes

 <!-- What changes have you made? -->
Add CssTransition wrapper

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
