### PR TITLE
Improve a11y on select component

### DIFF
--- a/packages/components/src/select/Select.js
+++ b/packages/components/src/select/Select.js
@@ -329,7 +329,7 @@ export default class Select extends Component {
     });
 
     const list = (
-      <ul className={dropdownClass} role="menu">
+      <ul className={dropdownClass} role="listbox">
         {!required && !canSearch && placeholder ? this.renderPlaceHolderOption() : ''}
         {canSearch && (
           <SearchBox
@@ -460,11 +460,16 @@ export default class Select extends Component {
           onTouchMove={this.handleTouchStart}
           onFocus={this.handleOnFocus}
           onBlur={this.handleOnBlur}
+          role="combobox"
+          aria-controls={id}
+          aria-expanded={open}
+          tabIndex={0}
         >
           <button
             disabled={disabled}
             className={buttonClass}
             type="button"
+            role="listbox"
             id={id}
             aria-expanded={open}
             onClick={this.handleButtonClick}

--- a/packages/components/src/select/Select.js
+++ b/packages/components/src/select/Select.js
@@ -469,7 +469,6 @@ export default class Select extends Component {
             disabled={disabled}
             className={buttonClass}
             type="button"
-            role="listbox"
             id={id}
             aria-expanded={open}
             onClick={this.handleButtonClick}

--- a/packages/components/src/select/Select.testingLibrary.spec.js
+++ b/packages/components/src/select/Select.testingLibrary.spec.js
@@ -235,7 +235,7 @@ describe('Select', () => {
       const input = getByPlaceholderText('Search...');
       user.type(input, 'o');
 
-      expect(getByRole('menu').children).toHaveLength(3);
+      expect(getByRole('listbox').children).toHaveLength(3);
     });
   });
 


### PR DESCRIPTION
## 🖼 Context

Testing a11y in new signup flow -  https://transferwise.atlassian.net/browse/USEC-3637
Select component is interpreted as a button. 

## 🚀 Changes

add combobox role - https://www.w3.org/TR/wai-aria-1.1/#combobox 
add lisbox role - https://www.w3.org/TR/wai-aria-1.1/#listbox - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role

## 🤔 Considerations
Before:
![Screenshot 2021-05-13 at 14 09 35 (2)](https://user-images.githubusercontent.com/51328507/118130125-edec2380-b3f4-11eb-8551-ef2ad440704e.png)
![Screenshot 2021-05-13 at 14 12 04 (2)](https://user-images.githubusercontent.com/51328507/118130407-399ecd00-b3f5-11eb-8b01-0db8fa1409f7.png)

After
![Screenshot 2021-05-13 at 14 07 19 (2)](https://user-images.githubusercontent.com/51328507/118130269-16741d80-b3f5-11eb-81e6-80099351c257.png)

![Screenshot 2021-05-13 at 14 07 58 (2)](https://user-images.githubusercontent.com/51328507/118130162-f8a6b880-b3f4-11eb-9353-320662688b7b.png)


## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
