### PR TITLE
fix: dynamic layout for actions

### DIFF
--- a/packages/dynamic-flows/src/flow/layoutService/LayoutService.js
+++ b/packages/dynamic-flows/src/flow/layoutService/LayoutService.js
@@ -199,7 +199,7 @@ function inlineReferences(layout, schemas, actions, model) {
       return inlineFormSchema(component, schemas, model);
     }
 
-    if (component.type === 'action') {
+    if (component.type === 'button') {
       return inlineAction(component, actions);
     }
 
@@ -229,9 +229,8 @@ function inlineFormSchema(formComponent, schemas, model) {
 }
 
 function inlineAction(actionComponent, actions) {
-  if (actionComponent.$ref) {
-    const newAction = getActionById(actions, actionComponent.$ref);
-    delete newAction.$ref;
+  if (actionComponent.action?.$ref) {
+    const newAction = getActionById(actions, actionComponent.action.$ref);
     return convertStepActionToDynamicAction(newAction);
   }
 

--- a/packages/dynamic-flows/src/flow/layoutService/LayoutService.spec.js
+++ b/packages/dynamic-flows/src/flow/layoutService/LayoutService.spec.js
@@ -295,12 +295,16 @@ describe('Given a utility service for handling dynamic layouts', () => {
           },
         },
         {
-          type: 'action',
-          $ref: '#submitMyDetails',
+          type: 'button',
+          action: {
+            $ref: '#submitMyDetails',
+          },
         },
         {
-          type: 'action',
-          $ref: '#submitMyAddress',
+          type: 'button',
+          action: {
+            $ref: '#submitMyAddress',
+          },
         },
       ];
 
@@ -364,8 +368,10 @@ describe('Given a utility service for handling dynamic layouts', () => {
               },
             },
             {
-              type: 'action',
-              $ref: '#submitMyAddress',
+              type: 'button',
+              action: {
+                $ref: '#submitMyAddress',
+              },
             },
           ],
         },
@@ -415,8 +421,10 @@ describe('Given a utility service for handling dynamic layouts', () => {
               },
             },
             {
-              type: 'action',
-              $ref: '#submitMyDetails',
+              type: 'button',
+              action: {
+                $ref: '#submitMyDetails',
+              },
             },
           ],
           right: [
@@ -427,8 +435,10 @@ describe('Given a utility service for handling dynamic layouts', () => {
               },
             },
             {
-              type: 'action',
-              $ref: '#submitMyAddress',
+              type: 'button',
+              action: {
+                $ref: '#submitMyAddress',
+              },
             },
           ],
         },


### PR DESCRIPTION
## 🖼 Context

The library doesn't define a layout called `action`, it defines `button`. The `button` contains an `action` object with `$ref` pointing to an `action.$id`.

## 🚀 Changes
Changes `action` type to `button` when parsing references.

## ✅ Checklist

- [X] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
