### PR TITLE
[Dynamic Flows] Fix Warning: Each child in a list should have a unique "key" prop

### DIFF
--- a/packages/dynamic-flows/src/layout/DynamicLayout.js
+++ b/packages/dynamic-flows/src/layout/DynamicLayout.js
@@ -86,13 +86,19 @@ const DynamicLayout = (props) => {
           <DynamicDecision key={getKey(component)} component={component} onAction={onAction} />
         );
       case 'final':
-        return <>{convertStepToLayout(component).map(renderComponent)}</>;
+        return (
+          <React.Fragment key={getKey(component)}>
+            {convertStepToLayout(component).map(renderComponent)}
+          </React.Fragment>
+        );
       default:
         return <div key={getKey(component)} />;
     }
   };
 
-  return <>{components.map(renderComponent)}</>;
+  return (
+    <React.Fragment key={getKey(components)}>{components.map(renderComponent)}</React.Fragment>
+  );
 };
 
 DynamicLayout.propTypes = {


### PR DESCRIPTION
## 🖼 Context

In development mode the following warning appears sometimes:

```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `DynamicLayout`. See https://fb.me/react-warning-keys for more information.
    in Fragment (created by DynamicLayout)
    in DynamicLayout (created by DynamicLayoutComponent)
    in DynamicLayoutComponent (created by UseDfv3FormStory)
```

This is because most paths in `DynamicLayout` component return a component with a `key` prop, but there is no `key` when returning a fragment.

## 🚀 Changes

Replaced the `<>` shorthand with `<React.Fragment>` and added a `key` prop.

## 🤔 Considerations

I didn't think too much about what the value of `key` should be. I followed what I saw in other components.

It is possible the new values result in unnecessary re-renders. Perhaps it would be best to use a static key for these.

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
