### PR TITLE
Align DynamicButton props to Button props

### DIFF
--- a/packages/dynamic-flows/src/layout/button/index.js
+++ b/packages/dynamic-flows/src/layout/button/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Button } from '@transferwise/components';
+import { Button, Priority, ControlType } from '@transferwise/components';
 import { actionModel, sizeModel, alignModel, marginModel } from '../models';
 import { getMarginBottom } from '../utils';
 
@@ -27,27 +27,11 @@ const DynamicButton = (props) => {
   };
 
   const getButtonType = (action) => {
-    switch (action.type) {
-      case 'primary':
-        return 'accent';
-      case 'success':
-        return 'positive';
-      case 'failure':
-      case 'warning':
-        return 'negative';
-      default:
-        return 'accent';
-    }
+    return Object.values(ControlType).includes(action.type) ? action.type : ControlType.ACCENT;
   };
 
   const getButtonPriority = (action) => {
-    switch (action.type) {
-      case 'primary':
-      case 'success':
-        return 'primary';
-      default:
-        return 'secondary';
-    }
+    return Object.values(Priority).includes(action.priority) ? action.priority : Priority.SECONDARY;
   };
 
   return (

--- a/packages/dynamic-flows/src/layout/button/spec.js
+++ b/packages/dynamic-flows/src/layout/button/spec.js
@@ -49,13 +49,13 @@ describe('Given a component for dynamically rendering buttons', () => {
     });
   });
 
-  describe('when priority is ommitted', () => {
+  describe('when priority and type are provided...', () => {
     const priorities = Object.values(Priority);
     const controlTypes = Object.values(ControlType);
 
     priorities.forEach((priority) => {
       controlTypes.forEach((controlType) => {
-        it(`should set the correct priority and type for ${priority}/${controlType}`, () => {
+        it(`...as ${priority}/${controlType}, it sets the correct priority and type`, () => {
           const localComponent = shallow(
             <DynamicButton
               component={{
@@ -79,6 +79,30 @@ describe('Given a component for dynamically rendering buttons', () => {
           expect(localComponent.find(Button).prop('type')).toBe(controlType);
         });
       });
+    });
+  });
+
+  describe('when priority or type are NOT provided', () => {
+    it(`defaults to secondary priority and accent type`, () => {
+      const localComponent = shallow(
+        <DynamicButton
+          component={{
+            component: 'button',
+            action: {
+              title: 'Submit',
+              url: '/example',
+              method: 'GET',
+            },
+            size: 'md',
+            align: 'center',
+            margin: 'md',
+          }}
+          onAction={jest.fn()}
+        />,
+      );
+
+      expect(localComponent.find(Button).prop('priority')).toBe('secondary');
+      expect(localComponent.find(Button).prop('type')).toBe('accent');
     });
   });
 });

--- a/packages/dynamic-flows/src/layout/button/spec.js
+++ b/packages/dynamic-flows/src/layout/button/spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { Button } from '@transferwise/components';
+import { Button, Priority, ControlType } from '@transferwise/components';
 
 import DynamicButton from '.';
 
@@ -17,7 +17,8 @@ describe('Given a component for dynamically rendering buttons', () => {
         title: 'Submit',
         url: '/example',
         method: 'GET',
-        type: 'primary',
+        type: 'accent',
+        priority: 'primary',
       },
       size: 'md',
       align: 'center',
@@ -45,6 +46,39 @@ describe('Given a component for dynamically rendering buttons', () => {
     });
     it('should broadcast onAction', () => {
       expect(onAction).toHaveBeenCalledWith(spec.action);
+    });
+  });
+
+  describe('when priority is ommitted', () => {
+    const priorities = Object.values(Priority);
+    const controlTypes = Object.values(ControlType);
+
+    priorities.forEach((priority) => {
+      controlTypes.forEach((controlType) => {
+        it(`should set the correct priority and type for ${priority}/${controlType}`, () => {
+          const localComponent = shallow(
+            <DynamicButton
+              component={{
+                component: 'button',
+                action: {
+                  title: 'Submit',
+                  url: '/example',
+                  method: 'GET',
+                  priority,
+                  type: controlType,
+                },
+                size: 'md',
+                align: 'center',
+                margin: 'md',
+              }}
+              onAction={jest.fn()}
+            />,
+          );
+
+          expect(localComponent.find(Button).prop('priority')).toBe(priority);
+          expect(localComponent.find(Button).prop('type')).toBe(controlType);
+        });
+      });
     });
   });
 });

--- a/packages/dynamic-flows/src/layout/models.js
+++ b/packages/dynamic-flows/src/layout/models.js
@@ -1,3 +1,4 @@
+import { ControlType, Priority } from '@transferwise/components';
 import Types from 'prop-types';
 
 const contextModel = Types.oneOf(['success', 'failure', 'warning', 'info', 'primary']);
@@ -7,7 +8,8 @@ const actionModel = Types.shape({
   url: Types.string.isRequired,
   method: Types.oneOf(['GET', 'POST', 'PUT', 'PATCH']).isRequired,
   disabled: Types.boolean,
-  type: contextModel,
+  type: Types.oneOf(Object.values(ControlType)),
+  priority: Types.oneOf(Object.values(Priority)),
   // eslint-disable-next-line react/forbid-prop-types
   data: Types.object,
 });


### PR DESCRIPTION
## 🖼 Context

`DynamicButton` is relying only on `type`, but the latest Neptune components `Button` [expects both `type` and `priority`](https://transferwise.github.io/neptune-web/components/inputs/Button).

This resulted in buttons rendering with `secondary` priority by default.

## 🚀 Changes

Align DynamicButton props to Button props.

## 🤔 Considerations

This is a breaking change.

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
