### PR TITLE
feat: add safe fallback for useIntl and injectIntl

### DIFF
--- a/packages/components/CONTRIBUTING.md
+++ b/packages/components/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Note: Please try to follow these rules for both exposed and internal components 
 
 ```javascript
 // don't
-export default injectIntl(SomeComponent);
+export default injectSafeIntl(SomeComponent);
 export default withSomeHoC(SomeComponent);
 
 // do 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -29,7 +29,7 @@ import { Provider, Button, Size } from '@transferwise/components';
 
 export default function Hello() {
   return (
-    <Provider i18n={{ locale: 'en-UK', messages: en }}>
+    <Provider i18n={{ locale: 'en-GB', messages: en }}>
       <Button size={Size.SMALL} block={true}>
         Hello Neptune
       </Button>

--- a/packages/components/src/common/closeButton/CloseButton.js
+++ b/packages/components/src/common/closeButton/CloseButton.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { useIntl } from 'react-intl';
 import { Cross as CrossIcon } from '@transferwise/icons';
 
+import { useSafeIntl } from '../safeIntl';
 import messages from './CloseButton.messages';
 
 import './CloseButton.css';
 
 export const CloseButton = React.forwardRef((props, ref) => {
-  const intl = useIntl();
+  const intl = useSafeIntl();
   const { onClick, className, size } = props;
   return (
     <button

--- a/packages/components/src/common/index.js
+++ b/packages/components/src/common/index.js
@@ -19,3 +19,4 @@ export { MarkdownNodeType } from './propsValues/markdownNodeType';
 export { Key } from './key';
 export * from './locale';
 export * from './commonProps';
+export * from './safeIntl';

--- a/packages/components/src/common/safeIntl/index.ts
+++ b/packages/components/src/common/safeIntl/index.ts
@@ -1,0 +1,2 @@
+export { injectSafeIntl } from './injectSafeIntl';
+export { useSafeIntl } from './useSafeIntl';

--- a/packages/components/src/common/safeIntl/injectSafeIntl.tsx
+++ b/packages/components/src/common/safeIntl/injectSafeIntl.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
+import { IntlContext } from 'react-intl';
+import { Opts, WrappedComponentProps, WithIntlProps } from 'react-intl/src/components/injectIntl';
+import { SafeIntlShape } from './types';
+import { defaultIntl } from './intl';
+
+function getDisplayName(Component: React.ComponentType<any>): string {
+  return Component.displayName || Component.name || 'Component';
+}
+
+export function injectSafeIntl<
+  IntlPropName extends string = 'intl',
+  P extends WrappedComponentProps<IntlPropName> = WrappedComponentProps<any>,
+  ForwardRef extends boolean = false,
+  T extends React.ComponentType<P> = any
+>(
+  WrappedComponent: React.ComponentType<P>,
+  options?: Opts<IntlPropName, ForwardRef>,
+): React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<WithIntlProps<P>> & React.RefAttributes<T>
+> & {
+  WrappedComponent: React.ComponentType<P>;
+} {
+  const { intlPropName = 'intl', forwardRef = false, enforceContext = true } = options || {};
+
+  const WithIntl: React.FC<P & { forwardedRef?: React.Ref<any> }> & {
+    WrappedComponent: React.ComponentType<P>;
+  } = (props) => (
+    <IntlContext.Consumer>
+      {(intl: SafeIntlShape): React.ReactNode => {
+        let safeIntl = intl;
+        if (enforceContext && !safeIntl) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            '<IntlProvider> needs to exist in the component ancestry.',
+            `Falling back to "${defaultIntl.locale}".`,
+          );
+          safeIntl = defaultIntl;
+        }
+        const intlProp = { [intlPropName]: safeIntl };
+
+        return (
+          <WrappedComponent {...props} {...intlProp} ref={forwardRef ? props.forwardedRef : null} />
+        );
+      }}
+    </IntlContext.Consumer>
+  );
+  WithIntl.displayName = `injectIntl(${getDisplayName(WrappedComponent)})`;
+  WithIntl.WrappedComponent = WrappedComponent;
+
+  if (forwardRef) {
+    return hoistNonReactStatics(
+      React.forwardRef<T, P>((props: P, ref) => <WithIntl {...props} forwardedRef={ref} />),
+      WrappedComponent,
+    ) as any;
+  }
+
+  return hoistNonReactStatics(WithIntl, WrappedComponent) as any;
+}

--- a/packages/components/src/common/safeIntl/intl.ts
+++ b/packages/components/src/common/safeIntl/intl.ts
@@ -1,0 +1,30 @@
+import { SafeIntlShape } from './types';
+import en from '../../i18n/en.json';
+
+function getMessage<Messages extends { [key: string]: string }>(
+  messages: Messages,
+  key: string,
+): string {
+  if (!Object.keys(messages).includes(key)) {
+    return key;
+  }
+
+  return messages[key];
+}
+
+export const defaultIntl: SafeIntlShape = {
+  locale: 'en-GB',
+  formatMessage: (descriptor, values, opts) => {
+    const messageId = String(descriptor.id);
+
+    let message = getMessage(en, messageId);
+
+    if (values) {
+      Object.entries(values).forEach(([key, value]) => {
+        message = message.replace(`{${key}}`, String(value));
+      });
+    }
+
+    return message;
+  },
+};

--- a/packages/components/src/common/safeIntl/types.ts
+++ b/packages/components/src/common/safeIntl/types.ts
@@ -1,0 +1,3 @@
+import { IntlShape } from 'react-intl';
+
+export type SafeIntlShape = Pick<IntlShape, 'locale' | 'formatMessage'>;

--- a/packages/components/src/common/safeIntl/useSafeIntl.ts
+++ b/packages/components/src/common/safeIntl/useSafeIntl.ts
@@ -1,0 +1,12 @@
+import { useIntl } from 'react-intl';
+import { defaultIntl } from './intl';
+
+export function useSafeIntl() {
+  try {
+    return useIntl();
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn(error.toString(), `Falling back to "${defaultIntl.locale}".`);
+    return defaultIntl;
+  }
+}

--- a/packages/components/src/dateInput/DateInput.js
+++ b/packages/components/src/dateInput/DateInput.js
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
-import { useIntl } from 'react-intl';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 import '../common/polyfills/closest';
 import Select from '../select';
 
-import { Size, DateMode, MonthFormat } from '../common';
+import { Size, DateMode, MonthFormat, useSafeIntl } from '../common';
 
 import { explodeDate, convertToLocalMidnight } from './utils';
 import { getMonthNames, isDateValid, isMonthAndYearFormat } from '../common/dateUtils';
@@ -32,7 +31,8 @@ const DateInput = ({
   id,
 }) => {
   const { isRTL } = useDirection();
-  const { locale } = useIntl();
+  const { locale } = useSafeIntl();
+
   const getDateObject = () => {
     if (value && isDateValid(value)) {
       return typeof value === 'string' ? convertToLocalMidnight(value) : value;

--- a/packages/components/src/dateLookup/dateTrigger/DateTrigger.js
+++ b/packages/components/src/dateLookup/dateTrigger/DateTrigger.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { formatDate } from '@transferwise/formatting';
 import { CrossCircle } from '@transferwise/icons';
@@ -9,7 +8,7 @@ import messages from './DateTrigger.messages';
 
 import Chevron from '../../chevron';
 
-import { Size, Position } from '../../common';
+import { Size, Position, useSafeIntl } from '../../common';
 import './DateTrigger.css';
 
 const DateTrigger = ({
@@ -22,7 +21,7 @@ const DateTrigger = ({
   onClick,
   onClear,
 }) => {
-  const { locale, formatMessage } = useIntl();
+  const { locale, formatMessage } = useSafeIntl();
 
   const handleKeyDown = (e) => {
     if (isKey({ keyType: 'Space', event: e }) || isKey({ keyType: 'Enter', event: e })) {

--- a/packages/components/src/dateLookup/dayCalendar/DayCalendar.js
+++ b/packages/components/src/dateLookup/dayCalendar/DayCalendar.js
@@ -1,9 +1,8 @@
 import React, { PureComponent } from 'react';
-import { injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { formatDate } from '@transferwise/formatting';
 
-import { MonthFormat } from '../../common';
+import { injectSafeIntl, MonthFormat } from '../../common';
 import Header from '../header';
 import DayCalendarTable from './table';
 
@@ -71,4 +70,4 @@ DayCalendar.defaultProps = {
   max: null,
 };
 
-export default injectIntl(DayCalendar);
+export default injectSafeIntl(DayCalendar);

--- a/packages/components/src/dateLookup/dayCalendar/table/DayCalendarTable.js
+++ b/packages/components/src/dateLookup/dayCalendar/table/DayCalendarTable.js
@@ -1,8 +1,8 @@
 import React, { PureComponent } from 'react';
-import { injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { formatDate } from '@transferwise/formatting';
 
+import { injectSafeIntl } from '../../../common';
 import { getDayNames, isWithinRange } from '../../../common/dateUtils';
 import { getStartOfDay } from '../../getStartOfDay';
 
@@ -135,4 +135,4 @@ DayCalendarTable.defaultProps = {
   max: null,
 };
 
-export default injectIntl(DayCalendarTable);
+export default injectSafeIntl(DayCalendarTable);

--- a/packages/components/src/dateLookup/monthCalendar/MonthCalendar.js
+++ b/packages/components/src/dateLookup/monthCalendar/MonthCalendar.js
@@ -1,8 +1,8 @@
 import React, { PureComponent } from 'react';
-import { injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { formatDate } from '@transferwise/formatting';
 
+import { injectSafeIntl } from '../../common';
 import Header from '../header';
 import MonthCalendarTable from './table';
 
@@ -64,4 +64,4 @@ MonthCalendar.defaultProps = {
   max: null,
 };
 
-export default injectIntl(MonthCalendar);
+export default injectSafeIntl(MonthCalendar);

--- a/packages/components/src/dateLookup/monthCalendar/table/MonthCalendarTable.js
+++ b/packages/components/src/dateLookup/monthCalendar/table/MonthCalendarTable.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { formatDate } from '@transferwise/formatting';
 
 import TableLink from '../../tableLink';
+import { useSafeIntl } from '../../../common';
 
 const ROWS = 3;
 const COLS = 4;
@@ -17,7 +17,7 @@ const MonthCalendarTable = ({
   placeholder,
   onSelect,
 }) => {
-  const { locale } = useIntl();
+  const { locale } = useSafeIntl();
 
   const getLink = (month) => (
     <TableLink

--- a/packages/components/src/dateLookup/yearCalendar/table/YearCalendarTable.js
+++ b/packages/components/src/dateLookup/yearCalendar/table/YearCalendarTable.js
@@ -1,16 +1,16 @@
 import React from 'react';
-import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { formatDate } from '@transferwise/formatting';
 
 import TableLink from '../../tableLink';
+import { useSafeIntl } from '../../../common';
 
 const ROWS = 5;
 const COLS = 4;
 const YEAR_ONLY_FORMAT = { year: 'numeric' };
 
 const YearCalendarTable = ({ selectedDate, min, max, viewYear, placeholder, onSelect }) => {
-  const { locale } = useIntl();
+  const { locale } = useSafeIntl();
   const startYear = viewYear - (viewYear % 20);
   const getLink = (year) => (
     <TableLink

--- a/packages/components/src/dynamicFieldDefinitionList/FormattedValue/FormattedValue.js
+++ b/packages/components/src/dynamicFieldDefinitionList/FormattedValue/FormattedValue.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { formatDate, formatNumber } from '@transferwise/formatting';
 import { formatUsingPattern } from '../utils/text-format';
+import { useSafeIntl } from '../../common';
 
 import './FormattedValue.css';
 
@@ -24,7 +24,7 @@ const getValueLabel = (options, value) => {
 const mask = (value) => new Array(value.length + 1).join('*');
 
 const FormattedValue = ({ field, value }) => {
-  const { locale } = useIntl();
+  const { locale } = useSafeIntl();
   const style = [];
   if (field.tagClassName && field.tagClassName.h3) {
     style.push('h3');

--- a/packages/components/src/lab/pagination/Pagination.js
+++ b/packages/components/src/lab/pagination/Pagination.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { useIntl } from 'react-intl';
 
 import { ChevronLeft, ChevronRight } from '@transferwise/icons';
 
+import { useSafeIntl } from '../../common';
 import PaginationLink from './paginationLink';
-
 import messages from './Pagination.messages';
 import './Pagination.css';
 
@@ -83,7 +82,7 @@ const Pagination = ({
     }
   }
 
-  const intl = useIntl();
+  const intl = useSafeIntl();
   return (
     <nav role="navigation" aria-label={intl.formatMessage(messages.ariaLabel)}>
       <ul className={classNames('tw-pagination', className)}>

--- a/packages/components/src/lab/pagination/paginationLink/PaginationLink.js
+++ b/packages/components/src/lab/pagination/paginationLink/PaginationLink.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { useIntl } from 'react-intl';
 
+import { useSafeIntl } from '../../../common';
 import messages from './PaginationLink.messages';
 
 const PaginationLink = ({ disabled, active, pageNumber, onClick, children }) => {
-  const intl = useIntl();
+  const intl = useSafeIntl();
 
   const handleClick = (e) => {
     e.preventDefault();

--- a/packages/components/src/money/Money.js
+++ b/packages/components/src/money/Money.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { formatMoney } from '@transferwise/formatting';
+import { useSafeIntl } from '../common';
 
 const Money = ({ amount, currency }) => {
-  const { locale } = useIntl();
+  const { locale } = useSafeIntl();
   return <>{formatMoney(amount, currency, locale)}</>;
 };
 

--- a/packages/components/src/moneyInput/MoneyInput.js
+++ b/packages/components/src/moneyInput/MoneyInput.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { isEmpty, isNumber, isNull } from '@transferwise/neptune-validation';
@@ -11,6 +10,7 @@ import { Key as keyValues } from '../common/key';
 
 import messages from './MoneyInput.messages';
 import { formatAmount, parseAmount } from './currencyFormatting';
+import { injectSafeIntl } from '../common';
 
 const Currency = PropTypes.shape({
   header: PropTypes.string,
@@ -383,4 +383,4 @@ MoneyInput.defaultProps = {
 // to be able to properly generate TS types, this is due to us wrapping this component in `injectIntl` before exporting
 export { MoneyInput };
 
-export default injectIntl(MoneyInput);
+export default injectSafeIntl(MoneyInput);

--- a/packages/components/src/phoneNumberInput/PhoneNumberInput.js
+++ b/packages/components/src/phoneNumberInput/PhoneNumberInput.js
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { isArray } from '@transferwise/neptune-validation';
 import classNames from 'classnames';
-import { Size } from '../common';
+import { Size, useSafeIntl } from '../common';
 
 import { useDirection } from '../common/hooks';
 
@@ -37,7 +36,7 @@ const PhoneNumberInput = (props) => {
     onBlur,
     countryCode,
   } = props;
-  const { locale } = useIntl();
+  const { locale } = useSafeIntl();
   const { isRTL } = useDirection();
 
   const getInitialValue = () => {

--- a/packages/components/src/provider/Provider.spec.js
+++ b/packages/components/src/provider/Provider.spec.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { render, waitFor, cleanup, screen } from '@testing-library/react';
 
 import Provider from '.';
 import closeButtonMessages from '../common/closeButton/CloseButton.messages';
+import { useSafeIntl } from '../common';
 
 describe('Provider', () => {
   beforeAll(() => {
@@ -43,7 +44,7 @@ describe('Provider', () => {
   ])('check locale value "%s"', (locale, expectedValue) => {
     const messages = {};
     const TestComponent = () => {
-      const intl = useIntl();
+      const intl = useSafeIntl();
       return <>locale: {intl.locale}</>;
     };
     const { container } = render(

--- a/packages/components/src/summary/Summary.js
+++ b/packages/components/src/summary/Summary.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React, { cloneElement } from 'react';
-import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import {
   CheckCircle as CheckCircleIcon,
@@ -10,7 +9,7 @@ import requiredIf from 'react-required-if';
 import { deprecated } from '../utilities';
 
 import Info from '../info';
-import { Status, Size } from '../common';
+import { Status, Size, useSafeIntl } from '../common';
 
 import messages from './Summary.messages';
 import './Summary.css';
@@ -43,7 +42,7 @@ const Summary = ({
   status,
   title,
 }) => {
-  const intl = useIntl();
+  const intl = useSafeIntl();
   const { isRTL } = useDirection();
 
   let media = illustration;

--- a/packages/components/src/upload/Upload.js
+++ b/packages/components/src/upload/Upload.js
@@ -1,5 +1,4 @@
 import React, { PureComponent } from 'react';
-import { injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Plus as PlusIcon } from '@transferwise/icons';
@@ -15,7 +14,7 @@ import {
 } from './utils';
 import './Upload.css';
 import messages from './Upload.messages';
-import { Status } from '../common';
+import { Status, injectSafeIntl } from '../common';
 
 const PROCESS_STATE = ['error', 'success'];
 
@@ -415,4 +414,4 @@ Upload.defaultProps = {
 // to be able to properly generate TS types, this is due to us wrapping this component in `injectIntl` before exporting
 export { Upload };
 
-export default injectIntl(Upload);
+export default injectSafeIntl(Upload);


### PR DESCRIPTION
## 🖼 Context

https://transferwise.atlassian.net/browse/DS-1103

We would like to add a graceful fallback for the internationalisation in case the `react-intl` provider is not set.

## 🚀 Changes

- Add `defaultIntl` and re-implement the used `react-intl` APIs
- Add `useSafeIntl` custom hook which returns `defaultIntl` if the original `intl` object cannot be accessed
- Add `injectSafeIntl` which sets the `deafultIntl` in case the property is missing from the `IntlContext.Consumer`

TODO:
- [ ] Expose useSafeIntl from @transferwise/components
- [ ] Use useSafeIntl in dynamic-flows

## 🤔 Considerations

With this approach, we have to implement all the APIs used from `react-intl` and make sure that it works the same way as it is in the library. Testing this behaviour would require us to render the components with and without a provider, and compare the results.

### FormattedMessage
The `<FormattedMessage />` syntax will not work, as it is not relies on the `intl` prop itself.

```jsx
❌ <FormattedMessage id="neptune.MoneyInput.Select.placeholder" />
✅ {intl.formatMessage({ id: 'neptune.MoneyInput.Select.placeholder' })
```

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
