### PR TITLE
Review fields in schema

### DIFF
--- a/packages/dynamic-flows/src/formControl/FormControl.spec.js
+++ b/packages/dynamic-flows/src/formControl/FormControl.spec.js
@@ -294,6 +294,22 @@ describe('FormControl', () => {
         });
       }
 
+      describe(`when it's disabled`, () => {
+        it(`should render the ${controlType} as disabled`, () => {
+          const allProps = { ...defaultProps, type: controlType, placeholder, disabled: true };
+          component = shallow(<FormControl {...allProps} />);
+          expect(component.find(selector).prop('disabled')).toBe(true);
+        });
+      });
+
+      describe(`when it's readOnly`, () => {
+        it(`should render the ${controlType} as readOnly`, () => {
+          const allProps = { ...defaultProps, type: controlType, placeholder, readOnly: true };
+          component = shallow(<FormControl {...allProps} />);
+          expect(component.find(selector).prop('readOnly')).toBe(true);
+        });
+      });
+
       testFocusHandler(() => {
         component.simulate('focus');
       });

--- a/packages/dynamic-flows/src/formControl/FormControl.spec.js
+++ b/packages/dynamic-flows/src/formControl/FormControl.spec.js
@@ -40,10 +40,6 @@ describe('FormControl', () => {
   testSimpleControl('number', 'input[type="number"]', 123456, 'Enter your numeric value here');
   testSimpleControl('textarea', 'textarea', 'Lorem ipsum', 'Please enter your feedback');
 
-  //   testTextControlValidation('text', 'input[type="text"]');
-  //   testTextControlValidation('password', 'input[type="password"]');
-  //   testTextControlValidation('textarea', 'textarea');
-
   testCustomControl('select', Select);
   testCustomControl('date', DateInput);
   testCustomControl('tel', PhoneNumberInput);
@@ -51,58 +47,6 @@ describe('FormControl', () => {
   testCustomControl('text', InputWithDisplayFormat);
   testCustomControl('textarea', TextareaWithDisplayFormat);
   testCustomControl('date-lookup', DateLookup);
-
-  // testAutoComplete('text', 'input');
-  // testAutoComplete('number', 'input');
-  // testAutoComplete('password', 'input');
-  // testAutoComplete('textarea', 'textarea');
-
-  //   xdescribe('type: number - validation', () => {
-  //     beforeEach(() => {
-  //       props = {
-  //         type: 'number',
-  //         value: null,
-  //         min: 2,
-  //         max: 5,
-  //         required: true,
-  //       };
-  //       formGroup = shallow(
-  //         <div className="form-group">
-  //           <FormControl {...{ ...defaultProps, ...props }} />
-  //         </div>,
-  //       );
-  //       component = formGroup.find('tw-form-control');
-  //       input = component.find('input');
-  //     });
-
-  //     testRequiredValidation(() => {
-  //       input.value = 4;
-  //       input.simulate('input');
-  //       $timeout.flush();
-  //     }, 4);
-
-  //     testMinMaxValidation(
-  //       () => {
-  //         // setBelowMin
-  //         input.value = 1;
-  //         input.simulate('input');
-  //         $timeout.flush();
-  //       },
-  //       () => {
-  //         // setAboveMax
-  //         input.value = 6;
-  //         input.simulate('input');
-  //         $timeout.flush();
-  //       },
-  //       () => {
-  //         // setValid
-  //         input.value = 4;
-  //         input.simulate('input');
-  //         $timeout.flush();
-  //       },
-  //       4,
-  //     );
-  //   });
 
   describe('type: select', () => {
     let selectElem;
@@ -280,28 +224,6 @@ describe('FormControl', () => {
     }, 1);
   });
 
-  //   xdescribe('type: file - validation', () => {
-  //     beforeEach(() => {
-  //       props.model = null;
-  //       formGroup = compileTemplate(
-  //         "<div class='form-group'> \
-  //             <label class='control-label'></label> \
-  //             <tw-form-control type='file' \
-  //               ng-model='model' \
-  //               ng-focus='onFocus()' \
-  //               ng-blur='onBlur()' \
-  //               ng-change='onChange(value)' \
-  //               required> \
-  //             </tw-form-control> \
-  //           </div>",
-  //       );
-  //       component = formGroup.find('tw-form-control');
-  //     });
-  //     it('should render twUpload', () => {
-  //       expect(component.find('tw-upload')).toBeTruthy();
-  //     });
-  //   });
-
   describe('type: date', () => {
     let dateInput;
 
@@ -330,67 +252,6 @@ describe('FormControl', () => {
     });
   });
 
-  //   xdescribe('type: date validation', () => {
-  //     const dayInput, yearInput;
-  //     beforeEach(() => {
-  //       props.model = null;
-  //       $scope.ngMin = '2015-04-01';
-  //       $scope.ngMax = '2017-03-24';
-  //       formGroup = compileTemplate(
-  //         "<div class='form-group'> \
-  //             <label class='control-label'></label> \
-  //             <tw-form-control type='date' \
-  //               ng-model='model' \
-  //               locale='en-GB' \
-  //               ng-min='ngMin' \
-  //               ng-max='ngMax' \
-  //               tw-minlength='' \
-  //               ng-required='true' \
-  //               ng-focus='onFocus()' \
-  //               ng-blur='onBlur()' \
-  //               ng-change='onChange(value)'> \
-  //             </tw-form-control> \
-  //           </div>",
-  //       );
-  //       component = formGroup.find('tw-form-control');
-  //       dayInput = component.find('.tw-date-day');
-  //       yearInput = component.find('.tw-date-year');
-  //     });
-
-  //     testRequiredValidation(() => {
-  //       // setValid 2016-01-01
-  //       dayInput.value = '01';
-  //       dayInput.simulate('input');
-  //       yearInput.value = '2016';
-  //       yearInput.simulate('input');
-  //     }, '2016-01-01');
-
-  //     testMinMaxValidation(
-  //       () => {
-  //         // setBelowMin 2010-01-01
-  //         dayInput.value = '01';
-  //         dayInput.simulate('input');
-  //         yearInput.value = '2010';
-  //         yearInput.simulate('input');
-  //       },
-  //       () => {
-  //         // setAboveMax 2020-01-01
-  //         dayInput.value = '01';
-  //         dayInput.simulate('input');
-  //         yearInput.value = '2020';
-  //         yearInput.simulate('input');
-  //       },
-  //       () => {
-  //         // setValid 2016-01-01
-  //         dayInput.value = '01';
-  //         dayInput.simulate('input');
-  //         yearInput.value = '2016';
-  //         yearInput.simulate('input');
-  //       },
-  //       '2016-01-01',
-  //     );
-  //   });
-
   describe('type: hidden', () => {
     let input;
 
@@ -405,38 +266,6 @@ describe('FormControl', () => {
       expect(input.prop('type')).toBe('hidden');
     });
   });
-
-  // function testAutoComplete(controlType, controlSelector) {
-  //   let control;
-
-  //   describe(`when autoComplete is enabled for a ${controlType} control`, () => {
-  //     beforeEach(() => {
-  //       props = {
-  //         type: controlType,
-  //         autoComplete: true,
-  //       };
-  //       control = shallow(<FormControl {...{ ...defaultProps, ...props }} />).find(controlSelector);
-  //     });
-
-  //     it('should disable autocomplete', () => {
-  //       expect(control.prop('autoComplete')).toBe('on');
-  //     });
-  //   });
-
-  //   describe(`when autoComplete is not enabled for a ${controlType} control`, () => {
-  //     beforeEach(() => {
-  //       props = {
-  //         type: controlType,
-  //         autoComplete: false,
-  //       };
-  //       control = shallow(<FormControl {...{ ...defaultProps, ...props }} />).find(controlSelector);
-  //     });
-
-  //     it('should enable autocomplete', () => {
-  //       expect(control.prop('autoComplete')).toBe('disabled');
-  //     });
-  //   });
-  // }
 
   function testSimpleControl(controlType, selector, valueToSet, placeholder) {
     let input;
@@ -592,70 +421,6 @@ describe('FormControl', () => {
     });
   }
 
-  //   function testTextControlValidation(controlType, selector) {
-  //     xdescribe('type: ' + controlType + ' - validation', () => {
-  //       beforeEach(() => {
-  //         props.model = '';
-  //         $scope.pattern = '[a-z]+';
-  //         formGroup = compileTemplate(
-  //           "<div class='form-group'> \
-  //               <label class='control-label'></label> \
-  //               <tw-form-control type='" +
-  //             controlType +
-  //             "' \
-  //                 ng-model='model' \
-  //                 ng-minlength='4' \
-  //                 ng-maxlength='6' \
-  //                 ng-pattern='pattern' \
-  //                 ng-required='true'> \
-  //               </tw-form-control> \
-  //             </div>",
-  //         );
-  //         input = formGroup.find(selector);
-  //         component = formGroup.find('tw-form-control');
-  //       });
-
-  //       testRequiredValidation(() => {
-  //         input.value = 'abcd';
-  //         input.simulate('input');
-  //         $timeout.flush();
-  //       }, 'abcd');
-
-  //       testLengthValidation(
-  //         () => {
-  //           input.value = 'abc';
-  //           input.simulate('input');
-  //           $timeout.flush();
-  //         },
-  //         () => {
-  //           input.value = 'abcdefg';
-  //           input.simulate('input');
-  //           $timeout.flush();
-  //         },
-  //         () => {
-  //           input.value = 'abcd';
-  //           input.simulate('input');
-  //           $timeout.flush();
-  //         },
-  //         'abcd',
-  //       );
-
-  //       testPatternValidation(
-  //         () => {
-  //           input.value = '1';
-  //           input.simulate('input');
-  //           $timeout.flush();
-  //         },
-  //         () => {
-  //           input.value = 'abcd';
-  //           input.simulate('input');
-  //           $timeout.flush();
-  //         },
-  //         'abcd',
-  //       );
-  //     });
-  //   }
-
   function testFocusHandler(performFocus) {
     describe('when focused', () => {
       beforeEach(performFocus);
@@ -693,120 +458,4 @@ describe('FormControl', () => {
       });
     });
   }
-
-  // function testRequiredValidation(setValidValue, expectedModel) {
-  //   xdescribe('when required and no value entered', () => {
-  //     it('should set ngModel.$invalid', () => {
-  //       expect(component.classList).toContain('ng-invalid');
-  //       expect(component.classList).toContain('ng-invalid-required');
-  //     });
-  //     it('should not bind to the model', () => {
-  //       expect(props.model).toBeFalsy();
-  //     });
-  //   });
-
-  //   xdescribe('when required and value is entered', () => {
-  //     beforeEach(setValidValue);
-
-  //     it('should set ngModel.$valid', () => {
-  //       expect(component.classList).toContain('ng-valid-required');
-  //     });
-  //     it('should bind to the model', () => {
-  //       expect(props.model).toBe(expectedModel);
-  //     });
-  //   });
-  // }
-
-  //   function testMinMaxValidation(setBelowMin, setAboveMax, setValid, expectedModel) {
-  //     xdescribe('when value is below min', () => {
-  //       beforeEach(setBelowMin);
-  //       it('should set ngModel.$invalid', () => {
-  //         expect(component.classList).toContain('ng-invalid');
-  //         expect(component.classList).toContain('ng-invalid-min');
-  //       });
-  //       it('should not bind to the model', () => {
-  //         expect(props.model).toBeFalsy();
-  //       });
-  //     });
-
-  //     xdescribe('when value is above max', () => {
-  //       beforeEach(setAboveMax);
-  //       it('should set ngModel.$invalid', () => {
-  //         expect(component.classList).toContain('ng-invalid');
-  //         expect(component.classList).toContain('ng-invalid-max');
-  //       });
-  //       it('should not bind to the model', () => {
-  //         expect(props.model).toBeFalsy();
-  //       });
-  //     });
-
-  //     xdescribe('when value is between min and max', () => {
-  //       beforeEach(setValid);
-  //       it('should set ngModel.$valid', () => {
-  //         expect(component.classList).toContain('ng-valid');
-  //         expect(component.classList).toContain('ng-valid-min');
-  //         expect(component.classList).toContain('ng-valid-max');
-  //       });
-  //       it('should bind the value to the model', () => {
-  //         expect(props.model).toBe(expectedModel);
-  //       });
-  //     });
-  //   }
-
-  //   function testLengthValidation(setBelowMin, setAboveMax, setValid, expectedModel) {
-  //     xdescribe('when entered value is shorter than min length', () => {
-  //       beforeEach(setBelowMin);
-  //       it('should set ngModel.$invalid', () => {
-  //         expect(component.classList).toContain('ng-invalid');
-  //         expect(component.classList).toContain('ng-invalid-minlength');
-  //       });
-  //       it('should not bind to the model', () => {
-  //         expect(props.model).toBeFalsy();
-  //       });
-  //     });
-
-  //     xdescribe('when entered value is longer than max length', () => {
-  //       beforeEach(setAboveMax);
-  //       it('should set ngModel.$valid when value is longer than min length', () => {
-  //         expect(component.classList).toContain('ng-invalid');
-  //         expect(component.classList).toContain('ng-invalid-maxlength');
-  //       });
-  //       it('should not bind to the model', () => {
-  //         expect(props.model).toBeFalsy();
-  //       });
-  //     });
-
-  //     xdescribe('when entered value is between min and max length', () => {
-  //       beforeEach(setValid);
-  //       it('should set ngModel.$valid', () => {
-  //         expect(component.classList).toContain('ng-valid-maxlength');
-  //       });
-  //       it('should bind to the model', () => {
-  //         expect(props.model).toBe(expectedModel);
-  //       });
-  //     });
-  //   }
-
-  //   function testPatternValidation(setInvalid, setValid, expectedModel) {
-  //     xdescribe('when entered value does not match pattern', () => {
-  //       beforeEach(setInvalid);
-  //       it('should set ngModel.$invalid', () => {
-  //         expect(component.classList).toContain('ng-invalid');
-  //         expect(component.classList).toContain('ng-invalid-pattern');
-  //       });
-  //       it('should not bind to the model', () => {
-  //         expect(props.model).toBeFalsy();
-  //       });
-  //     });
-
-  //     xdescribe('when entered value matches pattern', () => {
-  //       beforeEach(setValid);
-  //       it('should set ngModel.$valid', () => {
-  //         expect(component.classList).toContain('ng-valid-pattern');
-  //       });
-  //       it('should bind to the model', () => {
-  //         expect(props.model).toBe(expectedModel);
-  //       });
-  //     });
-  //   }
 });

--- a/packages/dynamic-flows/src/formControl/FormControl.story.js
+++ b/packages/dynamic-flows/src/formControl/FormControl.story.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { select, text } from '@storybook/addon-knobs';
+import { select, text, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import FormControl from './FormControl';
 
@@ -12,6 +12,8 @@ export const basic = () => {
   const control = select('control', Object.values(FormControl.Type), 'text');
   const size = select('size', Object.values(FormControl.Size), 'md');
   const label = text('label', 'label');
+  const disabled = boolean('disabled', false);
+  const readOnly = boolean('readOnly', false);
 
   const value = {
     text: 'a value',
@@ -20,6 +22,9 @@ export const basic = () => {
     'date-time': new Date(),
     tel: '+447573135343',
     number: 123456,
+    password: 'p455w0rd',
+    checkbox: true,
+    select: 2,
   };
 
   return (
@@ -37,8 +42,8 @@ export const basic = () => {
         { value: '2', label: 'Two' },
         { value: '3', label: 'Three', secondary: 'secondary text' },
       ]}
-      disabled={false}
-      readOnly={false}
+      disabled={disabled}
+      readOnly={readOnly}
       required={false}
       onChange={(val) => action(val)}
       onBlur={(val) => action(val)}

--- a/packages/dynamic-flows/src/formControl/ReviewFormControl.js
+++ b/packages/dynamic-flows/src/formControl/ReviewFormControl.js
@@ -1,0 +1,91 @@
+import React, { PureComponent } from 'react';
+import Types from 'prop-types';
+import { Checkbox } from '@transferwise/components';
+
+import { FormControlType } from '../common';
+
+const reviewFieldStyle = { fontWeight: 'semi-bold', fontSize: '16px' };
+
+export default class ReviewFormControl extends PureComponent {
+  getSelectedOption = (options) => {
+    let selectedOption;
+    if (this.props.selectedOption !== null && typeof this.props.selectedOption !== 'undefined') {
+      selectedOption = options.find((option) => this.props.selectedOption.value === option.value);
+    }
+    if (this.props.value !== null && typeof this.props.value !== 'undefined') {
+      selectedOption = options.find((option) => this.props.value === option.value);
+    }
+    return selectedOption;
+  };
+
+  getSelectedOptionFromIndex = (options, newIndex) => {
+    return options.find((option) => option.value === newIndex);
+  };
+
+  render() {
+    const { name, type, options, label, id, value } = this.props;
+
+    switch (type) {
+      case FormControlType.CHECKBOX:
+        return (
+          <Checkbox checked={value} label={label} required={false} disabled={false} readOnly />
+        );
+
+      case FormControlType.RADIO:
+      case FormControlType.SELECT: {
+        const option = this.getSelectedOption(options);
+        return (
+          <div>
+            <span style={reviewFieldStyle}>{option.label}</span> <span>{option.note}</span>
+          </div>
+        );
+      }
+
+      case FormControlType.HIDDEN:
+        return <input type="hidden" name={name} value={value} id={id} />;
+
+      default:
+        return <div style={reviewFieldStyle}>{value && value.toString()}</div>;
+    }
+  }
+}
+
+ReviewFormControl.propTypes = {
+  type: Types.oneOf(Object.values(FormControlType)),
+  name: Types.string.isRequired,
+  id: Types.string,
+  options: Types.arrayOf(
+    Types.shape({
+      label: Types.string.isRequired,
+      value: Types.oneOfType([
+        Types.number,
+        Types.string,
+        Types.bool,
+        Types.object,
+        Types.instanceOf(Date),
+      ]).isRequired,
+      note: Types.string,
+      secondary: Types.string,
+    }),
+  ),
+  label: Types.string,
+  value: Types.oneOfType([Types.string, Types.number, Types.bool, Types.object]),
+  selectedOption: Types.shape({
+    // eslint-disable-next-line react/forbid-prop-types
+    value: Types.any.isRequired,
+    label: Types.node,
+    icon: Types.node,
+    currency: Types.string,
+    note: Types.node,
+    secondary: Types.node,
+  }),
+};
+
+ReviewFormControl.defaultProps = {
+  type: FormControlType.TEXT,
+  id: null,
+  options: [],
+  value: null,
+  label: '',
+  selectedOption: null,
+};

--- a/packages/dynamic-flows/src/jsonSchemaForm/JsonSchemaForm.story.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/JsonSchemaForm.story.js
@@ -12,6 +12,7 @@ import audRecipientSchema from './schemas/audRecipient.json';
 import fileUploadPersistAsyncSchema from './schemas/uploadPersistAsync.json';
 import currencySchema from './schemas/currency.json';
 import validationAsyncSchema from './schemas/validationAsync.json';
+import reviewFieldsSchema from './schemas/reviewFields.json';
 
 export default {
   component: JsonSchemaForm,
@@ -29,13 +30,19 @@ export const basic = () => {
     'File upload persist async': fileUploadPersistAsyncSchema,
     validationAsync: validationAsyncSchema,
     currency: currencySchema,
+    reviewFields: reviewFieldsSchema,
   };
 
-  const schema = select('schema', schemas, simpleSchema);
+  const schema = select('schema', schemas, reviewFieldsSchema);
 
   const model = {
     number: 3,
     string: 'hi',
+    textarea: 'this is a long text',
+    password: '********',
+    checkbox: true,
+    select: 3,
+    radio: 2,
   };
 
   const stringError = text('error from server', '');

--- a/packages/dynamic-flows/src/jsonSchemaForm/schemaFormControl/SchemaFormControl.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/schemaFormControl/SchemaFormControl.js
@@ -3,6 +3,7 @@ import Types from 'prop-types';
 
 import { isNull, isUndefined } from '@transferwise/neptune-validation';
 import FormControl from '../../formControl';
+import ReviewFormControl from '../../formControl/ReviewFormControl';
 import { getValidModelParts } from '../../common/validation/valid-model';
 import { isOneOfSchema } from '../../common/schemaTypes/schemaTypes';
 import { FormControlType } from '../../common';
@@ -94,10 +95,17 @@ const SchemaFormControl = (props) => {
     placeholder: props.schema.placeholder,
     autoComplete: !props.schema.help,
     disabled: props.disabled || props.schema.disabled,
+    readOnly: props.readOnly || props.schema.readOnly,
     displayPattern: props.schema.displayFormat,
   };
 
-  return <FormControl type={controlType} value={safeValue} {...events} {...controlProps} />;
+  const isReview = controlProps.readOnly && controlProps.disabled;
+
+  return isReview ? (
+    <ReviewFormControl type={controlType} value={safeValue} {...controlProps} />
+  ) : (
+    <FormControl type={controlType} value={safeValue} {...events} {...controlProps} />
+  );
 };
 
 SchemaFormControl.propTypes = {
@@ -112,6 +120,7 @@ SchemaFormControl.propTypes = {
     help: Types.shape({}),
     displayFormat: Types.string,
     disabled: Types.bool,
+    readOnly: Types.bool,
   }).isRequired,
   onChange: Types.func.isRequired,
   onFocus: Types.func,
@@ -119,6 +128,7 @@ SchemaFormControl.propTypes = {
   translations: Types.shape({}),
   locale: Types.string,
   disabled: Types.bool,
+  readOnly: Types.bool,
 };
 
 SchemaFormControl.defaultProps = {
@@ -128,6 +138,7 @@ SchemaFormControl.defaultProps = {
   onFocus: null,
   onBlur: null,
   disabled: false,
+  readOnly: false,
 };
 
 export default SchemaFormControl;

--- a/packages/dynamic-flows/src/jsonSchemaForm/schemaFormControl/SchemaFormControl.spec.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/schemaFormControl/SchemaFormControl.spec.js
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import SchemaFormControl from '.';
 
 import FormControl from '../../formControl';
+import ReviewFormControl from '../../formControl/ReviewFormControl';
 
 describe('Given a component for rendering a form control based on a schema', () => {
   let component;
@@ -489,6 +490,24 @@ describe('Given a component for rendering a form control based on a schema', () 
         formControlComponent = component.find(FormControl);
 
         expect(formControlComponent.prop('disabled')).toBe(true);
+      });
+    });
+  });
+
+  describe('Review Fields in Schema', () => {
+    describe('when props contains disabled and readOnly properties', () => {
+      it('should render a ReviewFormControl instead of a FormControl', () => {
+        props = { ...props, disabled: true, readOnly: true };
+        component = shallow(<SchemaFormControl {...props} />);
+        expect(component.find(ReviewFormControl).exists()).toBe(true);
+      });
+    });
+
+    describe('when props.schema contains disabled and readOnly properties', () => {
+      it('should render a ReviewFormControl instead of a FormControl', () => {
+        props = { ...props, schema: { ...props.schema, disabled: true, readOnly: true } };
+        component = shallow(<SchemaFormControl {...props} />);
+        expect(component.find(ReviewFormControl).exists()).toBe(true);
       });
     });
   });

--- a/packages/dynamic-flows/src/jsonSchemaForm/schemas/reviewFields.json
+++ b/packages/dynamic-flows/src/jsonSchemaForm/schemas/reviewFields.json
@@ -1,0 +1,95 @@
+{
+  "title": "Object schema",
+  "type": "object",
+  "alert": {
+    "context": "warning",
+    "markdown": "Some **markdown** goes here"
+  },
+  "properties": {
+    "number": {
+      "type": "number",
+      "title": "Review Number",
+      "readOnly": true,
+      "disabled": true
+    },
+    "string": {
+      "type": "string",
+      "title": "Review Text",
+      "readOnly": true,
+      "disabled": true
+    },
+    "password": {
+      "type": "string",
+      "control": "password",
+      "title": "Review Password",
+      "readOnly": true,
+      "disabled": true
+    },
+    "checkbox": {
+      "type": "boolean",
+      "title": "Owned by customer",
+      "readOnly": true,
+      "disabled": true
+    },
+    "textarea": {
+      "type": "string",
+      "control": "textarea",
+      "title": "Review TextArea",
+      "readOnly": true,
+      "disabled": true
+    },
+    "select": {
+      "type": "integer",
+      "title": "Review Select",
+      "control": "select",
+      "placeholder": "Favourite number?",
+      "readOnly": true,
+      "disabled": true,
+      "oneOf": [
+        {
+          "title": "One",
+          "const": 1,
+          "description": "The first number"
+        },
+        {
+          "title": "Two",
+          "const": 2,
+          "description": "The second number"
+        },
+        {
+          "title": "Three",
+          "const": 3,
+          "description": "The third number",
+          "disabled": true
+        }
+      ]
+    },
+    "radio": {
+      "type": "integer",
+      "title": "Review Radio",
+      "control": "radio",
+      "placeholder": "Favourite number?",
+      "readOnly": true,
+      "disabled": true,
+      "oneOf": [
+        {
+          "title": "One",
+          "const": 1,
+          "description": "The first number"
+        },
+        {
+          "title": "Two",
+          "const": 2,
+          "description": "The second number"
+        },
+        {
+          "title": "Three",
+          "const": 3,
+          "description": "The third number",
+          "disabled": true
+        }
+      ]
+    }
+  },
+  "required": ["number", "string", "select"]
+}


### PR DESCRIPTION
## 🖼 Context

Draft implementation of review fields as part of the schema.

## 🚀 Changes

Introduced `ReviewFormControl` which is used by `SchemaFormControl` when the schema is inferred to be a review field. 
this is when both `disabled` and `readOnly` properties are `true`.

## 🤔 Considerations

This is just a draft. Not all schemas/cases were contemplated. Testing is incomplete.

## ✅ Checklist

- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
