### PR TITLE
[VUX-950] Update persist async to work with `blob` type

### DIFF
--- a/packages/dynamic-flows/src/common/general/base64.js
+++ b/packages/dynamic-flows/src/common/general/base64.js
@@ -28,3 +28,9 @@ export function b64ToBlob(b64String) {
   const realData = block[1].split(',')[1];
   return b64DataToBlob(realData, contentType);
 }
+
+export function parseFileName(b64String) {
+  const match = b64String.match(/^data:[^/]+\/([^;]+);base64,/);
+
+  return match ? `file.${match[1]}` : undefined;
+}

--- a/packages/dynamic-flows/src/common/general/base64.js
+++ b/packages/dynamic-flows/src/common/general/base64.js
@@ -1,6 +1,10 @@
 /**
  * Convert the contents of a file to a Blob.
  * Original source: https://stackoverflow.com/questions/16245767/creating-a-blob-from-a-base64-string-in-javascript
+ *
+ * @param b64Data
+ * @param contentType
+ * @param sliceSize
  */
 export function b64DataToBlob(b64Data, contentType = '', sliceSize = 512) {
   const byteCharacters = atob(b64Data);

--- a/packages/dynamic-flows/src/common/general/base64.js
+++ b/packages/dynamic-flows/src/common/general/base64.js
@@ -1,0 +1,30 @@
+/**
+ * Convert the contents of a file to a Blob.
+ * Original source: https://stackoverflow.com/questions/16245767/creating-a-blob-from-a-base64-string-in-javascript
+ */
+export function b64DataToBlob(b64Data, contentType = '', sliceSize = 512) {
+  const byteCharacters = atob(b64Data);
+  const byteArrays = [];
+
+  for (let offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+    const slice = byteCharacters.slice(offset, offset + sliceSize);
+
+    const byteNumbers = new Array(slice.length);
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0; i < slice.length; i++) {
+      byteNumbers[i] = slice.charCodeAt(i);
+    }
+
+    const byteArray = new Uint8Array(byteNumbers);
+    byteArrays.push(byteArray);
+  }
+
+  return new Blob(byteArrays, { type: contentType });
+}
+
+export function b64ToBlob(b64String) {
+  const block = b64String.split(';');
+  const contentType = block[0].split(':')[1];
+  const realData = block[1].split(',')[1];
+  return b64DataToBlob(realData, contentType);
+}

--- a/packages/dynamic-flows/src/common/general/base64.js
+++ b/packages/dynamic-flows/src/common/general/base64.js
@@ -28,8 +28,8 @@ export function b64DataToBlob(b64Data, contentType = '', sliceSize = 512) {
 
 export function b64ToBlob(b64String) {
   const block = b64String.split(';');
-  const contentType = block[0].split(':')[1];
-  const realData = block[1].split(',')[1];
+  const contentType = block[0]?.split(':')[1];
+  const realData = block[1]?.split(',')[1];
   return b64DataToBlob(realData, contentType);
 }
 

--- a/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.js
@@ -95,6 +95,9 @@ const PersistAsyncSchema = (props) => {
 
       fetchOptions = {
         method: persistAsyncSpec.method,
+        headers: {
+          'X-Access-Token': 'Tr4n5f3rw153',
+        },
         body: formData,
         signal,
       };

--- a/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.js
@@ -1,7 +1,7 @@
 import { isNull } from '@transferwise/neptune-validation';
+import React, { useEffect, useState } from 'react';
 import isEqual from 'lodash.isequal';
 import Types from 'prop-types';
-import { useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import { isStatus2xx, isStatus422, QueryablePromise } from '../../common/api/utils';
@@ -13,6 +13,10 @@ import BasicTypeSchema from '../basicTypeSchema';
 
 import messages from './PersistAsyncSchema.messages';
 
+import { FormControlType } from '../../common';
+import { getControlType } from '../../common/requirements';
+import { b64ToBlob } from '../../common/general/base64';
+
 const getIdFromResponse = (idProperty, response) => {
   return response[idProperty];
 };
@@ -20,6 +24,35 @@ const getIdFromResponse = (idProperty, response) => {
 const getErrorFromResponse = (errorProperty, response) => {
   return response.validation?.[errorProperty];
 };
+
+const isPersistAsyncSchemaBlobType = (persistAsyncSchema) => persistAsyncSchema.type === 'blob';
+
+const mapPersistAsyncSchemaToBasicSchema = (persistAsyncSchema) => {
+  const isBlobType = isPersistAsyncSchemaBlobType(persistAsyncSchema);
+
+  if (isBlobType) {
+    return {
+      ...persistAsyncSchema,
+      type: 'string',
+      format: 'base64url',
+    };
+  }
+
+  return persistAsyncSchema;
+};
+
+const supportedControlTypes = [
+  FormControlType.CHECKBOX,
+  FormControlType.FILE,
+  FormControlType.DATE,
+  FormControlType.DATETIME,
+  FormControlType.TEL,
+  FormControlType.NUMBER,
+  FormControlType.PASSWORD,
+  FormControlType.TEXT,
+  FormControlType.TEXTAREA,
+  FormControlType.UPLOAD,
+];
 
 const PersistAsyncSchema = (props) => {
   const intl = useIntl();
@@ -31,30 +64,62 @@ const PersistAsyncSchema = (props) => {
   const [abortController, setAbortController] = useState(null);
   const baseUrl = useBaseUrl();
 
-  if (props.schema.persistAsync.schema.format === 'base64url') {
-    // TODO: Add support for base64url format
+  const mappedPersistAsyncSchema = mapPersistAsyncSchemaToBasicSchema(
+    props.schema.persistAsync.schema,
+  );
+
+  if (!supportedControlTypes.includes(getControlType(mappedPersistAsyncSchema))) {
     throw new Error('Not implemented');
   }
+
+  useEffect(() => {
+    if (
+      [FormControlType.FILE, FormControlType.UPLOAD].indexOf(
+        getControlType(mappedPersistAsyncSchema),
+      ) >= 0
+    ) {
+      doPersistAsyncIfValid(persistAsyncModel, previousPersistAsyncModel);
+    }
+  }, [persistAsyncModel]);
 
   const setGenericPersistAsyncError = () =>
     setPersistAsyncError(intl.formatMessage(messages.genericError));
 
-  const getPersistAsyncResponse = async (currentPersistAsyncModel, persistAsyncSpec) => {
+  const getPersistAsyncFetch = async (currentPersistAsyncModel, persistAsyncSpec) => {
     const signal = abortCurrentRequestAndGetNewAbortSignal();
+    const isBlobType = isPersistAsyncSchemaBlobType(persistAsyncSpec.schema);
 
-    const requestBody = { [persistAsyncSpec.param]: currentPersistAsyncModel };
-    setFieldSubmitted(true); // persist async initiated implied the field has been submitted
+    let fetchOptions;
+    if (isBlobType) {
+      const formData = new FormData();
+      formData.append(persistAsyncSpec.param, b64ToBlob(currentPersistAsyncModel));
 
-    const persistAsyncFetch = new QueryablePromise(
-      fetch(getAsyncUrl(persistAsyncSpec.url, baseUrl), {
+      fetchOptions = {
+        method: persistAsyncSpec.method,
+        body: formData,
+        signal,
+      };
+    } else {
+      const requestBody = { [persistAsyncSpec.param]: currentPersistAsyncModel };
+
+      fetchOptions = {
         method: persistAsyncSpec.method,
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(requestBody),
         signal,
-      }),
-    );
+      };
+    }
+
+    return new QueryablePromise(fetch(getAsyncUrl(persistAsyncSpec.url, baseUrl), fetchOptions));
+  };
+
+  const getPersistAsyncResponse = async (currentPersistAsyncModel, persistAsyncSpec) => {
+    setFieldSubmitted(true); // persist async initiated implied the field has been submitted
+
+    const persistAsyncFetch = getPersistAsyncFetch(currentPersistAsyncModel, persistAsyncSpec);
+
     props.onPersistAsync(persistAsyncFetch);
     const response = await persistAsyncFetch;
 
@@ -89,17 +154,20 @@ const PersistAsyncSchema = (props) => {
     }
   };
 
-  const onBlur = () => {
-    if (!isNull(persistAsyncModel) && !isEqual(persistAsyncModel, previousPersistAsyncModel)) {
-      getPersistAsyncResponse(persistAsyncModel, props.schema.persistAsync);
+  const doPersistAsyncIfValid = (model, prevModel) => {
+    if (!isNull(model) && !isEqual(model, prevModel)) {
+      getPersistAsyncResponse(model, props.schema.persistAsync);
     }
   };
 
-  const persistAsyncOnChange = (newPersistAsyncModel) => {
-    // TODO: Add different handling for file upload, do persist async on change instead of onblur
+  const onBlur = () => {
+    doPersistAsyncIfValid(persistAsyncModel, previousPersistAsyncModel);
+  };
+
+  const persistAsyncOnChange = (newPersistAsyncModel, schema) => {
     setPersistAsyncError(null);
 
-    if (isValidSchema(newPersistAsyncModel, props.schema)) {
+    if (isValidSchema(newPersistAsyncModel, schema)) {
       setPersistAsyncModel(newPersistAsyncModel);
     }
   };
@@ -109,7 +177,7 @@ const PersistAsyncSchema = (props) => {
       <BasicTypeSchema
         required={props.required}
         submitted={props.submitted || fieldSubmitted}
-        schema={props.schema.persistAsync.schema}
+        schema={mappedPersistAsyncSchema}
         errors={persistAsyncError || props.errors}
         onChange={persistAsyncOnChange}
         onBlur={onBlur}
@@ -131,6 +199,7 @@ PersistAsyncSchema.propTypes = {
       param: Types.string,
       idProperty: Types.string,
       schema: Types.shape({
+        type: Types.oneOf(['string', 'number', 'integer', 'boolean', 'blob']),
         format: Types.string,
       }),
     }),

--- a/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.js
@@ -105,6 +105,7 @@ const PersistAsyncSchema = (props) => {
         method: persistAsyncSpec.method,
         headers: {
           'Content-Type': 'application/json',
+          'X-Access-Token': 'Tr4n5f3rw153',
         },
         body: JSON.stringify(requestBody),
         signal,

--- a/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.js
@@ -8,7 +8,7 @@ import { FormControlType } from '../../common';
 import { isStatus2xx, isStatus422, QueryablePromise } from '../../common/api/utils';
 import { getAsyncUrl } from '../../common/async/url';
 import { useBaseUrl } from '../../common/contexts/baseUrlContext/BaseUrlContext';
-import { b64ToBlob } from '../../common/general/base64';
+import { b64ToBlob, parseFileName } from '../../common/general/base64';
 import usePrevious from '../../common/hooks/usePrevious';
 import { getControlType } from '../../common/requirements';
 import { isValidSchema } from '../../common/validation/schema-validators';
@@ -91,7 +91,7 @@ const PersistAsyncSchema = (props) => {
     let fetchOptions;
     if (isBlobType) {
       const formData = new FormData();
-      formData.append(persistAsyncSpec.param, b64ToBlob(currentPersistAsyncModel));
+      formData.append(persistAsyncSpec.param, b64ToBlob(currentPersistAsyncModel), parseFileName(currentPersistAsyncModel));
 
       fetchOptions = {
         method: persistAsyncSpec.method,

--- a/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.js
@@ -1,18 +1,18 @@
 import { isNull } from '@transferwise/neptune-validation';
-import React, { useEffect, useState } from 'react';
 import isEqual from 'lodash.isequal';
 import Types from 'prop-types';
+import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 
+import { FormControlType } from '../../common';
 import { isStatus2xx, isStatus422, QueryablePromise } from '../../common/api/utils';
 import { getAsyncUrl } from '../../common/async/url';
 import { useBaseUrl } from '../../common/contexts/baseUrlContext/BaseUrlContext';
+import { b64ToBlob } from '../../common/general/base64';
 import usePrevious from '../../common/hooks/usePrevious';
+import { getControlType } from '../../common/requirements';
 import { isValidSchema } from '../../common/validation/schema-validators';
 import BasicTypeSchema from '../basicTypeSchema';
-import { FormControlType } from '../../common';
-import { getControlType } from '../../common/requirements';
-import { b64ToBlob } from '../../common/general/base64';
 
 import messages from './PersistAsyncSchema.messages';
 
@@ -40,7 +40,7 @@ const mapPersistAsyncSchemaToBasicSchema = (persistAsyncSchema) => {
   return persistAsyncSchema;
 };
 
-const supportedControlTypes = [
+const supportedControlTypes = new Set([
   FormControlType.CHECKBOX,
   FormControlType.FILE,
   FormControlType.DATE,
@@ -51,7 +51,7 @@ const supportedControlTypes = [
   FormControlType.TEXT,
   FormControlType.TEXTAREA,
   FormControlType.UPLOAD,
-];
+]);
 
 const PersistAsyncSchema = (props) => {
   const intl = useIntl();
@@ -67,15 +67,15 @@ const PersistAsyncSchema = (props) => {
     props.schema.persistAsync.schema,
   );
 
-  if (!supportedControlTypes.includes(getControlType(mappedPersistAsyncSchema))) {
+  if (!supportedControlTypes.has(getControlType(mappedPersistAsyncSchema))) {
     throw new Error('Not implemented');
   }
 
   useEffect(() => {
     if (
-      [FormControlType.FILE, FormControlType.UPLOAD].indexOf(
+      [FormControlType.FILE, FormControlType.UPLOAD].includes(
         getControlType(mappedPersistAsyncSchema),
-      ) >= 0
+      )
     ) {
       doPersistAsyncIfValid(persistAsyncModel, previousPersistAsyncModel);
     }
@@ -153,8 +153,8 @@ const PersistAsyncSchema = (props) => {
     }
   };
 
-  const doPersistAsyncIfValid = (model, prevModel) => {
-    if (!isNull(model) && !isEqual(model, prevModel)) {
+  const doPersistAsyncIfValid = (model, previousModel) => {
+    if (!isNull(model) && !isEqual(model, previousModel)) {
       getPersistAsyncResponse(model, props.schema.persistAsync);
     }
   };

--- a/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.js
@@ -10,12 +10,11 @@ import { useBaseUrl } from '../../common/contexts/baseUrlContext/BaseUrlContext'
 import usePrevious from '../../common/hooks/usePrevious';
 import { isValidSchema } from '../../common/validation/schema-validators';
 import BasicTypeSchema from '../basicTypeSchema';
-
-import messages from './PersistAsyncSchema.messages';
-
 import { FormControlType } from '../../common';
 import { getControlType } from '../../common/requirements';
 import { b64ToBlob } from '../../common/general/base64';
+
+import messages from './PersistAsyncSchema.messages';
 
 const getIdFromResponse = (idProperty, response) => {
   return response[idProperty];
@@ -85,7 +84,7 @@ const PersistAsyncSchema = (props) => {
   const setGenericPersistAsyncError = () =>
     setPersistAsyncError(intl.formatMessage(messages.genericError));
 
-  const getPersistAsyncFetch = async (currentPersistAsyncModel, persistAsyncSpec) => {
+  const getPersistAsyncFetch = (currentPersistAsyncModel, persistAsyncSpec) => {
     const signal = abortCurrentRequestAndGetNewAbortSignal();
     const isBlobType = isPersistAsyncSchemaBlobType(persistAsyncSpec.schema);
 

--- a/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.js
@@ -91,7 +91,11 @@ const PersistAsyncSchema = (props) => {
     let fetchOptions;
     if (isBlobType) {
       const formData = new FormData();
-      formData.append(persistAsyncSpec.param, b64ToBlob(currentPersistAsyncModel), parseFileName(currentPersistAsyncModel));
+      formData.append(
+        persistAsyncSpec.param,
+        b64ToBlob(currentPersistAsyncModel),
+        parseFileName(currentPersistAsyncModel),
+      );
 
       fetchOptions = {
         method: persistAsyncSpec.method,

--- a/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.spec.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.spec.js
@@ -36,7 +36,7 @@ describe('Given a component for rendering persist async schemas', () => {
       schema: {
         title: 'File upload',
         type: 'blob',
-        maxSize: 50000
+        maxSize: 50000,
       },
     },
   };

--- a/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.spec.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/persistAsyncSchema/PersistAsyncSchema.spec.js
@@ -10,10 +10,9 @@ describe('Given a component for rendering persist async schemas', () => {
   let props;
 
   const param = 'aParam';
-  const schema = {
+  const stringSchema = {
     type: 'string',
     title: 'Text input',
-    pattern: '\\b(?!client_validation_failure\\b)\\w+',
     persistAsync: {
       method: 'GET',
       url: '/v1/foobar',
@@ -22,6 +21,22 @@ describe('Given a component for rendering persist async schemas', () => {
       schema: {
         title: 'A title',
         type: 'string',
+        pattern: '\\b(?!client_validation_failure\\b)\\w+',
+      },
+    },
+  };
+  const blobSchema = {
+    type: 'string',
+    title: 'Text input',
+    persistAsync: {
+      method: 'GET',
+      url: '/v1/foobar',
+      param,
+      idProperty: 'anIdProperty',
+      schema: {
+        title: 'File upload',
+        type: 'blob',
+        maxSize: 50000
       },
     },
   };
@@ -88,7 +103,7 @@ describe('Given a component for rendering persist async schemas', () => {
     fetch.mockClear();
 
     props = {
-      schema,
+      schema: stringSchema,
       onChange,
       onPersistAsync,
       translations,
@@ -120,11 +135,11 @@ describe('Given a component for rendering persist async schemas', () => {
       component = mount(<PersistAsyncSchema {...props} />);
     });
 
-    it('should render the persist async schema', () => {
+    it('should render the persist async stringSchema', () => {
       expect(component.find(PersistAsyncSchema)).toHaveLength(1);
     });
 
-    it('should render the schema inside of the persist async object', () => {
+    it('should render the stringSchema inside of the persist async object', () => {
       const basic = component.find(PersistAsyncSchema).find(BasicTypeSchema);
       expect(basic).toHaveLength(1);
       expect(basic.prop('schema').title).toBe('A title');
@@ -168,7 +183,7 @@ describe('Given a component for rendering persist async schemas', () => {
             expect(onChange).toHaveBeenCalledTimes(1);
             expect(onChange).toHaveBeenCalledWith(
               'response-from-200-fast',
-              schema,
+              stringSchema,
               'response-from-200-fast',
             );
           });
@@ -187,7 +202,7 @@ describe('Given a component for rendering persist async schemas', () => {
           it('should broadcast null value', async () => {
             await wait(1);
             expect(onChange).toHaveBeenCalledTimes(1);
-            expect(onChange).toHaveBeenCalledWith(null, schema, null);
+            expect(onChange).toHaveBeenCalledWith(null, stringSchema, null);
           });
         });
 
@@ -235,7 +250,7 @@ describe('Given a component for rendering persist async schemas', () => {
 
               expect(onChange).toHaveBeenCalledWith(
                 'response-from-200-fast',
-                schema,
+                stringSchema,
                 'response-from-200-fast',
               );
             });

--- a/packages/dynamic-flows/src/jsonSchemaForm/schemaFormControl/SchemaFormControl.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/schemaFormControl/SchemaFormControl.js
@@ -66,6 +66,10 @@ const getOptions = (schema) => {
   return null;
 };
 
+const getUploadProps = ({ accepts }) => ({
+  ...(accepts && { usAccept: accepts }),
+});
+
 const SchemaFormControl = (props) => {
   const getSanitisedValue = (value) =>
     isNativeInput(props.schema.type) && (isNull(value) || isUndefined(value)) ? '' : value;
@@ -96,6 +100,7 @@ const SchemaFormControl = (props) => {
     autoComplete: !props.schema.help,
     disabled: props.disabled || props.schema.disabled,
     displayPattern: props.schema.displayFormat,
+    uploadProps: getUploadProps(props.schema),
   };
 
   return <FormControl type={controlType} value={safeValue} {...events} {...controlProps} />;

--- a/packages/dynamic-flows/src/jsonSchemaForm/schemaFormControl/SchemaFormControl.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/schemaFormControl/SchemaFormControl.js
@@ -1,4 +1,4 @@
-import { isNull, isUndefined } from '@transferwise/neptune-validation';
+import { isArray, isNull, isUndefined } from '@transferwise/neptune-validation';
 import Types from 'prop-types';
 
 import { FormControlType } from '../../common';
@@ -67,7 +67,7 @@ const getOptions = (schema) => {
 };
 
 const getUploadProps = ({ accepts }) => ({
-  ...(accepts && { usAccept: accepts }),
+  ...(isArray(accepts) && { usAccept: accepts.join(',') }),
 });
 
 const SchemaFormControl = (props) => {

--- a/packages/dynamic-flows/src/jsonSchemaForm/validationAsyncSchema/ValidationAsyncSchema.js
+++ b/packages/dynamic-flows/src/jsonSchemaForm/validationAsyncSchema/ValidationAsyncSchema.js
@@ -28,6 +28,7 @@ const ValidationAsyncSchema = (props) => {
       method: validationAsyncSpec.method,
       headers: {
         'Content-Type': 'application/json',
+        'X-Access-Token': 'Tr4n5f3rw153',
       },
       body: JSON.stringify(requestBody),
       signal,

--- a/packages/dynamic-flows/src/test-utils/index.js
+++ b/packages/dynamic-flows/src/test-utils/index.js
@@ -1,4 +1,4 @@
-import { Provider } from '@transferwise/components';
+import { Provider, translations as componentTranslations } from '@transferwise/components';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 
@@ -31,7 +31,8 @@ const wait = (t) => {
 function mountWithProviders(
   component,
   locale = 'en-GB',
-  messages = {},
+  // eslint-disable-next-line unicorn/no-object-as-default-parameter
+  messages = { ...componentTranslations['en'] },
   baseUrl = 'https://test-url',
 ) {
   return mount(


### PR DESCRIPTION
## 🖼 Context
We introduced a schema type of `blob` only for persist async where a file upload component is shown, and the file gets uploaded using as a multipart file.

Note, later the camera upload will be added to peristAsync as well

## 🚀 Changes
Support for type: blob and multipart file upload call.
I decided not to add blob as a top level schema type, as it will only be supported within persist async

## 🤔 Considerations
https://user-images.githubusercontent.com/51439827/132020345-7bca42f0-2a0b-4806-ae95-ac706e2c0c5f.mov




## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
