### PR TITLE
[VUX-1305] Sticky primary action

### DIFF
--- a/packages/dynamic-flows/src/layout/StickyLayout.js
+++ b/packages/dynamic-flows/src/layout/StickyLayout.js
@@ -1,0 +1,39 @@
+import Types from 'prop-types';
+
+const StickyLayout = (props) => {
+  const { children, stickyContent } = props;
+
+  // const isStickyButton = true;
+  //
+  // if (isStickyButton) {
+  //   component.action.margin = 'xs';
+  //
+  //   return (
+  //     <>
+  //       <div className="visible-xs-block visible-sm-block">
+  //         <Sticky>
+  //           <div className="p-a-2">{getButton(component)}</div>
+  //         </Sticky>
+  //       </div>
+  //
+  //       <div className="hidden-xs hidden-sm">{getButton(component)}</div>
+  //     </>
+  //   );
+  // }
+
+  return (
+    <div className="sticky-container">
+      <div className="sticky-content">
+        <div className="sticky-content-scroll">{children}</div>
+      </div>
+      <div className="sticky-footer">{stickyContent}</div>
+    </div>
+  );
+};
+
+StickyLayout.propTypes = {
+  children: Types.node.isRequired,
+  stickyContent: Types.node.isRequired,
+};
+
+export default StickyLayout;

--- a/packages/dynamic-flows/src/layout/StickyLayout.js
+++ b/packages/dynamic-flows/src/layout/StickyLayout.js
@@ -1,5 +1,9 @@
 import Types from 'prop-types';
 
+export const isPositionStickySupported = () => {
+  return window?.CSS?.supports('position', 'sticky');
+};
+
 const StickyLayout = (props) => {
   const { children, stickyContent } = props;
 

--- a/packages/dynamic-flows/src/layout/StickyLayout.js
+++ b/packages/dynamic-flows/src/layout/StickyLayout.js
@@ -3,24 +3,6 @@ import Types from 'prop-types';
 const StickyLayout = (props) => {
   const { children, stickyContent } = props;
 
-  // const isStickyButton = true;
-  //
-  // if (isStickyButton) {
-  //   component.action.margin = 'xs';
-  //
-  //   return (
-  //     <>
-  //       <div className="visible-xs-block visible-sm-block">
-  //         <Sticky>
-  //           <div className="p-a-2">{getButton(component)}</div>
-  //         </Sticky>
-  //       </div>
-  //
-  //       <div className="hidden-xs hidden-sm">{getButton(component)}</div>
-  //     </>
-  //   );
-  // }
-
   return (
     <div className="sticky-container">
       <div className="sticky-content">

--- a/packages/dynamic-flows/src/layout/StickyLayout.js
+++ b/packages/dynamic-flows/src/layout/StickyLayout.js
@@ -4,12 +4,10 @@ const StickyLayout = (props) => {
   const { children, stickyContent } = props;
 
   return (
-    <div className="sticky-container">
-      <div className="sticky-content">
-        <div className="sticky-content-scroll">{children}</div>
-      </div>
+    <>
+      {children}
       <div className="sticky-footer">{stickyContent}</div>
-    </div>
+    </>
   );
 };
 

--- a/packages/dynamic-flows/src/layout/StickyLayout.less
+++ b/packages/dynamic-flows/src/layout/StickyLayout.less
@@ -19,5 +19,9 @@
     box-shadow: inset 0 1px 0 0 #e2e6e8;
     padding-top: 16px;
     background: white;
+
+    > * {
+      margin-bottom: 0 !important;
+    }
   }
 }

--- a/packages/dynamic-flows/src/layout/StickyLayout.less
+++ b/packages/dynamic-flows/src/layout/StickyLayout.less
@@ -1,24 +1,13 @@
-.sticky-container {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-
-  .sticky-content {
-    flex: 1;
-    position: relative;
-    overflow: hidden scroll;
-
-    .sticky-content-scroll {
-      position: absolute;
-    }
-  }
-
+@media (max-width: 768px) {
   .sticky-footer {
+    position: sticky;
+    bottom: 0;
     width: 100%;
-    box-shadow: inset 0 1px 0 0 #e2e6e8;
     padding-top: 16px;
+    padding-bottom: 16px;
+    margin-bottom: -16px;
     background: white;
+    box-shadow: inset 0 1px 0 0 #e2e6e8;
 
     > * {
       margin-bottom: 0 !important;

--- a/packages/dynamic-flows/src/layout/StickyLayout.less
+++ b/packages/dynamic-flows/src/layout/StickyLayout.less
@@ -1,0 +1,23 @@
+.sticky-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  .sticky-content {
+    flex: 1;
+    position: relative;
+    overflow: hidden scroll;
+
+    .sticky-content-scroll {
+      position: absolute;
+    }
+  }
+
+  .sticky-footer {
+    width: 100%;
+    box-shadow: inset 0 1px 0 0 #e2e6e8;
+    padding-top: 16px;
+    background: white;
+  }
+}

--- a/packages/dynamic-flows/src/layout/StickyLayout.less
+++ b/packages/dynamic-flows/src/layout/StickyLayout.less
@@ -1,16 +1,14 @@
-@media (max-width: 768px) {
-  .sticky-footer {
-    position: sticky;
-    bottom: 0;
-    width: 100%;
-    padding-top: 16px;
-    padding-bottom: 16px;
-    margin-bottom: -16px;
-    background: white;
-    box-shadow: inset 0 1px 0 0 #e2e6e8;
+.sticky-footer {
+  position: sticky;
+  bottom: 0;
+  width: 100%;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  margin-bottom: -16px;
+  background: white;
+  box-shadow: inset 0 1px 0 0 #e2e6e8;
 
-    > * {
-      margin-bottom: 0 !important;
-    }
+  > * {
+    margin-bottom: 0 !important;
   }
 }

--- a/packages/dynamic-flows/src/main.less
+++ b/packages/dynamic-flows/src/main.less
@@ -1,3 +1,4 @@
 @import './formControl/FormControl.less';
 @import './step/cameraStep/cameraCapture/CameraCapture.less';
 @import './step/cameraStep/cameraCapture/screens/NoCameraAccess.less';
+@import './layout/StickyLayout.less';

--- a/packages/dynamic-flows/src/step/layoutStep/LayoutStep.js
+++ b/packages/dynamic-flows/src/step/layoutStep/LayoutStep.js
@@ -4,6 +4,9 @@ import Types from 'prop-types';
 import DynamicLayout from '../../layout';
 
 import { convertStepToLayout, inlineReferences } from './layoutService';
+import StickyLayout from '../../layout/StickyLayout';
+import { convertStepActionToDynamicAction } from './layoutService/LayoutService';
+import DynamicButton from '../../layout/button';
 
 const getComponents = (step) => {
   if (!step || isEmpty(step) || (!step.layout && !step.type)) {
@@ -15,8 +18,42 @@ const getComponents = (step) => {
   return inlineReferences(layout, step.schemas, step.actions);
 };
 
+const useStickyLayout = (stepSpecification) =>
+  stepSpecification.actions.filter((action) => action.type === 'primary').length;
+
 const LayoutStep = (props) => {
   const { stepSpecification, submitted, model, errors, onModelChange, onAction } = props;
+
+  if (useStickyLayout(stepSpecification)) {
+    const stickyButton = stepSpecification.actions
+      .filter((action) => action.type === 'primary')
+      .map((action) => ({ ...action, margin: 'xs' }))
+      .pop();
+    const newStepSpecification = {
+      ...stepSpecification,
+      actions: stepSpecification.actions.filter((action) => action?.$id !== stickyButton?.$id),
+    };
+
+    const bodyComponents = getComponents(newStepSpecification);
+
+    const stickyButtonComponent = convertStepActionToDynamicAction(stickyButton);
+
+    return (
+      <StickyLayout
+        stickyContent={<DynamicButton component={stickyButtonComponent} onAction={onAction} />}
+      >
+        <DynamicLayout
+          components={bodyComponents}
+          submitted={submitted}
+          model={model}
+          errors={errors}
+          baseUrl={baseUrl}
+          onAction={onAction}
+          onModelChange={onModelChange}
+        />
+      </StickyLayout>
+    );
+  }
 
   const components = getComponents(stepSpecification);
 

--- a/packages/dynamic-flows/src/step/layoutStep/LayoutStep.js
+++ b/packages/dynamic-flows/src/step/layoutStep/LayoutStep.js
@@ -27,7 +27,6 @@ const LayoutStep = (props) => {
   if (useStickyLayout(stepSpecification)) {
     const stickyButton = stepSpecification.actions
       .filter((action) => action.type === 'primary')
-      .map((action) => ({ ...action, margin: 'xs' }))
       .pop();
     const newStepSpecification = {
       ...stepSpecification,

--- a/packages/dynamic-flows/src/step/layoutStep/LayoutStep.js
+++ b/packages/dynamic-flows/src/step/layoutStep/LayoutStep.js
@@ -46,7 +46,6 @@ const LayoutStep = (props) => {
           submitted={submitted}
           model={model}
           errors={errors}
-          baseUrl={baseUrl}
           onAction={onAction}
           onModelChange={onModelChange}
         />

--- a/packages/dynamic-flows/src/step/layoutStep/LayoutStep.js
+++ b/packages/dynamic-flows/src/step/layoutStep/LayoutStep.js
@@ -2,7 +2,7 @@ import { isEmpty } from '@transferwise/neptune-validation';
 import Types from 'prop-types';
 
 import DynamicLayout from '../../layout';
-import StickyLayout from '../../layout/StickyLayout';
+import StickyLayout, {isPositionStickySupported} from '../../layout/StickyLayout';
 import DynamicButton from '../../layout/button';
 
 import { convertStepToLayout, inlineReferences } from './layoutService';
@@ -54,7 +54,7 @@ const LayoutStep = (props) => {
     );
   };
 
-  if (singlePrimaryActionExists(stepSpecification)) {
+  if (singlePrimaryActionExists(stepSpecification) && isPositionStickySupported()) {
     const { newStepSpecification, stickyButton } = removePrimaryButtonFromSchema(stepSpecification);
     const bodyComponents = getComponents(newStepSpecification);
     const stickyButtonComponent = convertStepActionToDynamicAction(stickyButton);

--- a/packages/dynamic-flows/src/step/layoutStep/layoutService/LayoutService.js
+++ b/packages/dynamic-flows/src/step/layoutStep/layoutService/LayoutService.js
@@ -168,7 +168,10 @@ function convertFinalStepImageToDynamicImage(image) {
 }
 
 function convertStepActionToDynamicAction(action) {
-  const newAction = { ...action, title: action.title };
+  if (!action) {
+    return {};
+  }
+  const newAction = { ...action, title: action?.title };
   return {
     type: 'button',
     action: newAction,
@@ -310,4 +313,4 @@ function addMissingTitleToStep(step) {
   return step.layout;
 }
 
-export { convertStepToLayout, inlineReferences };
+export { convertStepToLayout, inlineReferences, convertStepActionToDynamicAction };


### PR DESCRIPTION
## 🖼 Context
We have a UX issue in our IDWL with flow, where the CTA is below the screen fold on mobile. A fix is the make the CTA sticky on mobile devices, similarly to how iOS/Android do it.

## 🚀 Changes
- Make CTA sticky for mobile screens
- Condition to stick: 1 primary action exists in JSON schema

https://user-images.githubusercontent.com/51439827/148806034-f98149cf-1b93-46c6-9850-f2eda3a11417.mov


## 🤔 Considerations
- Only make sticky for mobile viewport sizes?
- Sticky footer sticks to the **bottom of container element, NOT viewport**

## ✅ Checklist

- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
