### PR TITLE
feat(css): update disabled styles

### DIFF
--- a/packages/css/src/less/buttons.less
+++ b/packages/css/src/less/buttons.less
@@ -369,12 +369,6 @@ input[type="button"] {
     color: var(--color-content-accent);
   }
 
-  &[disabled] {
-    background-color: var(--color-background-neutral);
-    border-color: var(--color-interactive-disabled);
-    color: var(--color-content-disabled);
-  }
-
   .form-control-placeholder {
     text-overflow: ellipsis;
     overflow: hidden;

--- a/packages/css/src/less/core/_scaffolding.less
+++ b/packages/css/src/less/core/_scaffolding.less
@@ -95,15 +95,6 @@ a,
       color: var(--color-content-accent-active);
     }
   }
-
-  &[disabled] {
-    color: var(--color-content-disabled);
-    cursor: default;
-
-    .bg-primary & {
-      color: @color-navy-content-disabled;
-    }
-  }
 }
 
 html.ios-click {
@@ -382,6 +373,12 @@ video {
 
 [hidden] {
   display: none; // Normalize 8.0.1
+}
+
+.disabled,
+:disabled {
+  filter: grayscale(1);
+  opacity: 0.45;
 }
 
 // Only display content to screen readers

--- a/packages/css/src/less/forms/bootstrap-forms.less
+++ b/packages/css/src/less/forms/bootstrap-forms.less
@@ -172,26 +172,6 @@ output {
     color: var(--color-content-tertiary);
   }
 
-  // Disabled and read-only inputs
-  //
-  // HTML5 says that controls under a fieldset > legend:first-child won't be
-  // disabled if the fieldset is disabled. Due to implementation difficulty, we
-  // don't honor that edge case; we style them as disabled anyway.
-  &[disabled],
-  &[readonly],
-  fieldset[disabled] & {
-    background-color: var(--color-background-neutral);
-    color: var(--color-content-disabled);
-    border-color: var(--color-interactive-disabled);
-
-    &::placeholder {
-      color: var(--color-content-disabled);
-    }
-
-    // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655
-    opacity: 1;
-  }
-
   &[disabled],
   fieldset[disabled] & {
     cursor: @cursor-disabled;
@@ -911,18 +891,6 @@ input[type='checkbox'] {
     &.has-focus:hover,
     &:focus-within {
       border-color: var(--color-interactive-accent-active);
-    }
-  }
-
-  &[disabled],
-  &[readonly],
-  fieldset[disabled] &,
-  &.disabled,
-  &.readonly {
-    label {
-      color: var(--color-content-disabled);
-      border-color: var(--color-interactive-disabled);
-      background-color: var(--color-background-neutral);
     }
   }
 

--- a/packages/css/src/less/forms/checkbox-radio.less
+++ b/packages/css/src/less/forms/checkbox-radio.less
@@ -86,13 +86,7 @@
 
   &[disabled],
   input[type='checkbox']:disabled + & {
-    background-color: var(--color-background-neutral);
-    border-color: var(--color-interactive-disabled) !important;
     cursor: @cursor-disabled;
-
-    .tw-checkbox-check {
-      color: var(--color-content-disabled);
-    }
   }
 
   .checkbox.has-error &,
@@ -102,10 +96,6 @@
     &[checked],
     &.checked {
       background-color: var(--color-interactive-negative);
-    }
-
-    &[disabled] {
-      background-color: var(--color-background-neutral);
     }
   }
 
@@ -180,13 +170,7 @@
 
   &[disabled],
   &.disabled {
-    background-color: var(--color-background-neutral);
-    border-color: var(--color-interactive-disabled) !important;
     cursor: @cursor-disabled;
-
-    .tw-radio-check {
-      background-color: var(--color-interactive-disabled);
-    }
   }
 
   .radio.has-error &,
@@ -197,18 +181,6 @@
     &.checked .tw-radio-check {
       background-color: var(--color-interactive-negative);
     }
-
-    &[disabled] .tw-radio-check {
-      background-color: var(--color-interactive-disabled);
-    }
-  }
-}
-
-.checkbox {
-  &.disabled label,
-  &.disabled label:hover {
-    border-color: var(--color-interactive-disabled);
-    color: var(--color-content-disabled) !important;
   }
 }
 

--- a/packages/css/src/less/input-groups.less
+++ b/packages/css/src/less/input-groups.less
@@ -77,17 +77,6 @@
       border-color: var(--color-interactive-accent-active);
     }
   }
-
-  &.disabled {
-    .input-group-addon {
-      background-color: var(--color-background-neutral);
-      border-color: var(--color-interactive-disabled);
-    }
-
-    &:active .input-group-addon {
-      border-color: var(--color-interactive-secondary-active);
-    }
-  }
 }
 
 // Sizing options

--- a/packages/css/src/less/mixins/_buttons.less
+++ b/packages/css/src/less/mixins/_buttons.less
@@ -50,27 +50,6 @@
     background-image: none;
   }
 
-  &.disabled,
-  &[disabled],
-  fieldset[disabled] & {
-    &,
-    &:hover,
-    &:focus,
-    &.focus,
-    &:active,
-    &.active {
-      background-color: var(--color-background-neutral);
-      border-color: var(--color-interactive-disabled);
-      color: var(--color-content-disabled);
-
-      &.btn-priority-2 {
-        background-color: @background;
-        border-color: var(--color-interactive-disabled);
-        color: var(--color-content-disabled);
-      }
-    }
-  }
-
   .badge {
     color: @background;
     background-color: @color;

--- a/packages/css/src/less/tick.less
+++ b/packages/css/src/less/tick.less
@@ -14,15 +14,6 @@
     transform: translateX(0.5px) rotate(-45deg);
     transform-origin: left bottom;
     left: var(--size-8);
-
-    .tw-checkbox-button[disabled] &,
-    input[type='checkbox']:disabled + .tw-checkbox-button & {
-      background-color: var(--color-interactive-disabled);
-    }
-
-    .tw-checkbox-button + .tw-checkbox-button & {
-      background-color: var(--color-interactive-disabled);
-    }
   }
 
   .has-error {


### PR DESCRIPTION
## 🖼 Context

Update disabled colors on buttons and inputs to match our updated designs.

https://transferwise.atlassian.net/browse/DS-1465
https://transferwise.atlassian.net/browse/DS-1552

## 🚀 Changes

- Apply a grayscale filter with opacity on `:disabled, .disabled` selectors.

https://developer.mozilla.org/en-US/docs/Web/CSS/filter-function/grayscale()

### Before

<img width="440" alt="Screenshot 2022-01-10 at 19 58 42" src="https://user-images.githubusercontent.com/71433023/148824795-9c15bc4f-28fa-4f06-8fb4-2c399731ecbb.png">
<img width="362" alt="Screenshot 2022-01-10 at 19 57 49" src="https://user-images.githubusercontent.com/71433023/148824798-1c89b612-2510-4646-8765-e14e824ddeee.png">
<img width="442" alt="Screenshot 2022-01-10 at 19 57 37" src="https://user-images.githubusercontent.com/71433023/148824801-798e6633-ee76-4844-bfed-18e0ca5b2c4d.png">
<img width="441" alt="Screenshot 2022-01-10 at 19 57 08" src="https://user-images.githubusercontent.com/71433023/148824803-aad6490c-3276-44e7-979f-d835a712213b.png">

### After

<img width="439" alt="Screenshot 2022-01-10 at 20 00 23" src="https://user-images.githubusercontent.com/71433023/148824835-cd903c8d-5bea-40ad-ada8-fe6c63786aa8.png">
<img width="355" alt="Screenshot 2022-01-10 at 19 59 49" src="https://user-images.githubusercontent.com/71433023/148824832-e858f323-7f72-491e-9d20-e72400bc3621.png">
<img width="437" alt="Screenshot 2022-01-10 at 19 59 41" src="https://user-images.githubusercontent.com/71433023/148824829-b82dcc1d-4486-4f7a-810b-138e828530de.png">
<img width="441" alt="Screenshot 2022-01-10 at 19 59 10" src="https://user-images.githubusercontent.com/71433023/148824827-ca051053-cdbf-476a-86b7-c4d6beda66fe.png">

## 🤔 Considerations

- Hover effects are still visible grayscaled

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
