### PR TITLE
feat: adding theming to the process indicator icon

### DIFF
--- a/packages/components/src/processIndicator/ProcessIndicator.js
+++ b/packages/components/src/processIndicator/ProcessIndicator.js
@@ -2,7 +2,9 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 
-import { Status, Size } from '../common';
+import { Status, Size, Theme } from '../common';
+
+import './ProcessIndicator.css';
 
 const radius = { xs: 11, sm: 22, xl: 61 };
 export const ANIMATION_DURATION_IN_MS = 1500;
@@ -71,9 +73,9 @@ class ProcessIndicator extends Component {
   };
 
   render() {
-    const { className, 'data-testid': dataTestId } = this.props;
+    const { className, 'data-testid': dataTestId, theme } = this.props;
     const { size, status } = this.state;
-    const classes = classNames(`process process-${size}`, className, {
+    const classes = classNames(`process process-${size} process--${theme}`, className, {
       [`process-danger`]: status === Status.FAILED,
       [`process-stopped`]: status === Status.HIDDEN,
       [`process-success`]: status === Status.SUCCEEDED,
@@ -104,6 +106,7 @@ ProcessIndicator.propTypes = {
   onAnimationCompleted: PropTypes.func,
   className: PropTypes.string,
   'data-testid': PropTypes.string,
+  theme: PropTypes.oneOf(['light', 'dark']),
 };
 
 ProcessIndicator.defaultProps = {
@@ -112,6 +115,7 @@ ProcessIndicator.defaultProps = {
   onAnimationCompleted: null,
   className: undefined,
   'data-testid': null,
+  theme: Theme.LIGHT,
 };
 
 export default ProcessIndicator;

--- a/packages/components/src/processIndicator/ProcessIndicator.less
+++ b/packages/components/src/processIndicator/ProcessIndicator.less
@@ -1,0 +1,28 @@
+@import (reference) '@transferwise/neptune-css/src/variables/neptune-tokens.less';
+
+.process--dark {
+  .process-icon-horizontal,
+  .process-icon-vertical,
+  .process-circle {
+    stroke: @color-navy-content-accent;
+    background-color: @color-navy-content-accent;
+  }
+
+  &.process-danger {
+    .process-icon-horizontal,
+    .process-icon-vertical,
+    .process-circle {
+      stroke: @color-navy-content-negative;
+      background-color: @color-navy-content-negative;
+    }
+  }
+
+  &.process-success {
+    .process-icon-horizontal,
+    .process-icon-vertical,
+    .process-circle {
+      stroke: @color-navy-content-positive;
+      background-color: @color-navy-content-positive;
+    }
+  }
+}

--- a/packages/components/src/processIndicator/ProcessIndicator.story.js
+++ b/packages/components/src/processIndicator/ProcessIndicator.story.js
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import { select } from '@storybook/addon-knobs';
 
-import { Size, Status } from '../common';
+import { Size, Status, Theme } from '../common';
 
 import ProcessIndicator from './ProcessIndicator';
 
@@ -13,6 +13,16 @@ export default {
 export const Basic = () => {
   const size = select('size', Object.values(Size), Size.EXTRA_SMALL);
   const status = select('status', Object.values(Status), Status.PROCESSING);
+  const theme = select('Theme', [Theme.LIGHT, Theme.DARK], Theme.LIGHT);
 
-  return <ProcessIndicator status={status} size={size} onAnimationCompleted={(s) => action(s)} />;
+  return (
+    <div className={theme === 'dark' ? 'bg--dark p-a-3' : 'p-a-3'}>
+      <ProcessIndicator
+        status={status}
+        size={size}
+        theme={theme}
+        onAnimationCompleted={(s) => action(s)}
+      />
+    </div>
+  );
 };


### PR DESCRIPTION
## 🖼 Context

<!-- Why is this PR necessary? Please include links to mockups, JIRA ticket or other relevant documentation. -->
The process indicator doesn't look good on navy backgrounds. Spoke with Mate, and we've agreed that since theming isn't quite ready, for now we'll add this here.

<img width="320" alt="Screenshot 2022-01-21 at 10 39 04" src="https://user-images.githubusercontent.com/61203573/150588342-ec39d889-4b02-4246-a2f9-8594c39c8d38.png">

## 🚀 Changes

 <!-- What changes have you made? -->
Added colours for a dark theme.

<img width="179" alt="Screenshot 2022-01-21 at 14 28 58" src="https://user-images.githubusercontent.com/61203573/150588590-d586d6e7-f9e2-4f98-b49a-35e785d1fdba.png">

<img width="180" alt="Screenshot 2022-01-21 at 14 28 50" src="https://user-images.githubusercontent.com/61203573/150588591-9f0ae12a-5187-4ed8-9c23-e3c0e96996af.png">

<img width="180" alt="Screenshot 2022-01-21 at 14 28 38" src="https://user-images.githubusercontent.com/61203573/150588592-d3501183-806e-47b4-8fbb-29e7e3eab9d1.png">


## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
