### PR TITLE
NABC-106 - adding support for rates in MoneyInput

### DIFF
--- a/packages/components/src/moneyInput/MoneyInput.js
+++ b/packages/components/src/moneyInput/MoneyInput.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import Select from '../select';
 import './MoneyInput.css';
 
-import { formatAmount, parseAmount } from './currencyFormatting';
+import { formatAmount, parseAmount, getRateInAllFormats } from './currencyFormatting';
 
 const Currency = Types.shape({
   header: Types.string,
@@ -16,8 +16,13 @@ const Currency = Types.shape({
 });
 const CUSTOM_ACTION = 'CUSTOM_ACTION';
 
-const formatAmountIfSet = (amount, currency, locale) => {
-  return amount ? formatAmount(amount, currency, locale) : '';
+const formatAmountIfSet = (amount, currency, locale, isRate) => {
+  if (amount) {
+    return isRate
+      ? getRateInAllFormats(amount, currency, 'GBP').formats.decimal.output
+      : formatAmount(amount, currency, locale);
+  }
+  return '';
 };
 
 export default class MoneyInput extends Component {
@@ -36,6 +41,7 @@ export default class MoneyInput extends Component {
     customActionLabel: Types.node,
     onCustomAction: Types.func,
     classNames: Types.objectOf(Types.string),
+    isRate: Types.bool,
   };
 
   static defaultProps = {
@@ -51,6 +57,7 @@ export default class MoneyInput extends Component {
     customActionLabel: '',
     onCustomAction: null,
     classNames: {},
+    isRate: false,
   };
 
   state = {
@@ -59,6 +66,7 @@ export default class MoneyInput extends Component {
       this.props.amount,
       this.props.selectedCurrency.currency,
       this.props.locale,
+      this.props.isRate,
     ),
   };
 
@@ -69,6 +77,7 @@ export default class MoneyInput extends Component {
           nextProps.amount,
           nextProps.selectedCurrency.currency,
           nextProps.locale,
+          this.props.isRate,
         ),
       });
     }
@@ -79,7 +88,12 @@ export default class MoneyInput extends Component {
     this.setState({
       formattedAmount: value,
     });
-    const parsed = parseAmount(value, this.props.selectedCurrency.currency, this.props.locale);
+    const parsed = parseAmount(
+      value,
+      this.props.selectedCurrency.currency,
+      this.props.locale,
+      this.props.isRate,
+    );
     if (!Number.isNaN(parsed)) {
       this.props.onAmountChange(parsed);
     }
@@ -110,6 +124,7 @@ export default class MoneyInput extends Component {
         previousState.formattedAmount,
         this.props.selectedCurrency.currency,
         this.props.locale,
+        this.props.isRate,
       );
       if (Number.isNaN(parsed)) {
         return {
@@ -121,6 +136,7 @@ export default class MoneyInput extends Component {
           parsed,
           this.props.selectedCurrency.currency,
           this.props.locale,
+          this.props.isRate,
         ),
       };
     });

--- a/packages/components/src/moneyInput/MoneyInput.spec.js
+++ b/packages/components/src/moneyInput/MoneyInput.spec.js
@@ -62,6 +62,7 @@ describe('Money Input', () => {
       amount: 1000,
       onAmountChange: jest.fn(),
       onCurrencyChange: jest.fn(),
+      isRate: false,
     };
     component = shallow(<MoneyInput {...props} />);
   });
@@ -453,5 +454,13 @@ describe('Money Input', () => {
     component.setProps({ locale: 'en-US', numberFormatPrecision: 3 });
     component.setProps({ placeholder: 12345.67 });
     expect(amountInput().prop('placeholder')).toBe('formatted 12345.67, en-US, eur');
+  });
+
+  it('formats input as rate if isRate is on', () => {
+    component.setProps({ isRate: true });
+
+    enterAmount(0.1234567);
+
+    expect(amountInput().prop('value')).toBe('0.123456');
   });
 });

--- a/packages/components/src/moneyInput/MoneyInput.story.js
+++ b/packages/components/src/moneyInput/MoneyInput.story.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import MoneyInput from './MoneyInput';
-import { select, number } from '@storybook/addon-knobs';
+import { select, number, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 export default {
@@ -12,6 +12,7 @@ export const basic = () => {
   const size = select('size', ['sm', 'md', 'lg'], 'md');
   const locale = select('locale', ['en-GB', 'jp-JP'], 'en-GB');
   const amount = number('amount', 1000);
+  const isRate = boolean('isRate', true);
 
   return (
     <MoneyInput
@@ -51,6 +52,7 @@ export const basic = () => {
         currency: 'eur',
         searchable: 'Spain, Germany, France, Austria',
       }}
+      isRate={isRate}
     />
   );
 };

--- a/packages/components/src/moneyInput/currencyFormatting.js
+++ b/packages/components/src/moneyInput/currencyFormatting.js
@@ -1,6 +1,6 @@
-import { formatAmount } from '@transferwise/formatting';
+import { formatAmount, getRateInAllFormats } from '@transferwise/formatting';
 
-export { formatAmount };
+export { formatAmount, getRateInAllFormats };
 
 // TODO: do not duplicate this between formatting and components
 const currencyDecimals = {
@@ -62,10 +62,8 @@ function getDecimalSeparator(locale) {
   return isNumberLocaleSupported() ? (1.1).toLocaleString(locale)[1] : '.';
 }
 
-export function parseAmount(number, currency, locale) {
+export function parseAmount(number, currency, locale, isRate) {
   const validLocale = getValidLocale(locale);
-
-  const precision = getCurrencyDecimals(currency);
   const groupSeparator = isNumberLocaleSupported() ? (1000).toLocaleString(validLocale)[1] : ',';
   const decimalSeparator = getDecimalSeparator(validLocale);
   const trimmedNumber = number.replace(/\s/g, '');
@@ -77,6 +75,13 @@ export function parseAmount(number, currency, locale) {
     new RegExp(`\\${decimalSeparator}`, 'g'),
     '.',
   );
+
+  if (isRate) {
+    const impreciseRate = parseFloat(parseFloat(numberWithStandardDecimalSeparator));
+    return Math.abs(impreciseRate);
+  }
+
+  const precision = getCurrencyDecimals(currency);
   const parsedAmount = parseFloat(
     parseFloat(numberWithStandardDecimalSeparator).toFixed(precision),
   );

--- a/packages/docs/pages/css/Alert.mdx
+++ b/packages/docs/pages/css/Alert.mdx
@@ -1,0 +1,97 @@
+<p className="lead">
+  Provide contextual feedback messages for typical user actions with the handful of available and
+  flexible alert messages.
+</p>
+
+## Usage 
+```js
+import '@transferwise/neptune-css/dist/alerts.css
+```
+
+## Examples
+
+Wrap any text and an optional dismiss button in <code>.alert</code> and one of the four contextual classes (e.g., <code>.alert-success</code>) for basic alert messages.
+
+<div class="alert alert-info-info">
+  <h4>No default class</h4>
+  <p>
+    Alerts don't have default classes, only base and modifier classes. A default gray alert doesn't
+    make too much sense, so you're required to specify a type via contextual class. Choose from
+    success, info, warning, or danger.
+  </p>
+</div>
+<div class="alert alert-success" role="alert">
+  <strong>Well done!</strong> You successfully read this important alert message.
+</div>
+<div class="alert alert-info arrow" role="alert">
+  <strong>Heads up!</strong> This alert needs your attention, but it's not super important.
+</div>
+<div class="alert alert-warning" role="alert">
+  <strong>Warning!</strong> Better check yourself, you're not looking too good.
+</div>
+<div class="alert alert-danger" role="alert">
+  <strong>Oh snap!</strong> Change a few things up and try submitting again.
+</div>
+
+```html
+<div class="alert alert-success" role="alert">...</div>
+<div class="alert alert-info" role="alert">...</div>
+<div class="alert alert-warning" role="alert">...</div>
+<div class="alert alert-danger" role="alert">...</div>
+```
+
+## Connecting alerts
+
+Use the <code>.arrow</code> classes to visually attach alerts to other elements.
+
+<div class="alert alert-success arrow" role="alert">
+  <strong>Well done!</strong> You successfully read this important alert message.
+</div>
+<div class="alert alert-info arrow arrow-right" role="alert">
+  <strong>Heads up!</strong> This alert needs your attention, but it's not super important.
+</div>
+<div class="alert alert-warning arrow arrow-bottom arrow-center" role="alert">
+  <strong>Warning!</strong> Better check yourself, you're not looking too good.
+</div>
+
+```html
+<div class="alert alert-success arrow" role="alert">...</div>
+<div class="alert alert-info arrow arrow-right" role="alert">...</div>
+<div class="alert alert-warning arrow arrow-bottom arrow-center" role="alert">...</div>
+```
+
+## Links in alerts
+
+Use the <code>.alert-link</code> utility class to quickly provide matching colored links within any alert.
+
+<div class="alert alert-success" role="alert">
+  <strong>Well done!</strong> You successfully read <a href="#" class="alert-link">this important alert message</a>.
+</div>
+<div class="alert alert-info" role="alert">
+  <strong>Heads up!</strong> This <a href="#" class="alert-link">alert needs your attention</a>, but it's not super important.
+</div>
+<div class="alert alert-warning" role="alert">
+  <strong>Warning!</strong> Better check yourself, you're <a href="#" class="alert-link">not looking too good</a>.
+</div>
+<div class="alert alert-danger" role="alert">
+  <strong>Oh snap!</strong> <a href="#" class="alert-link">Change a few things up</a> and try submitting again.
+</div>
+
+```html
+<div class="alert alert-success" role="alert">
+  <a href="#" class="alert-link">...</a>
+</div>
+<div class="alert alert-info" role="alert">
+  <a href="#" class="alert-link">...</a>
+</div>
+<div class="alert alert-warning" role="alert">
+  <a href="#" class="alert-link">...</a>
+</div>
+<div class="alert alert-danger" role="alert">
+  <a href="#" class="alert-link">...</a>
+</div>
+```
+
+export const meta = {
+  name: 'Alert',
+};


### PR DESCRIPTION
## 🖼 Context

Currently the [MoneyInput](https://neptune.wise.com/components/money-input/) is formatted according to whatever the default is for that currency.
I want to use the MoneyInput for the desired rate field in auto conversion because:
- it looks good
- it has lots of built in checks that I want to use
- it'll fix a bug where when you scroll with the input being focussed it changes the entered amount

This PR adds an optional param that formats the number in the MoneyInput as a Rate instead of as currency

https://transferwise.atlassian.net/browse/NABC-106

## 🚀 Changes

add optional param to format the number as rate instead of currency

## 🤔 Considerations

😬 It's a MoneyInput not a RateInput 😬 My argument in favor of the change is that maybe Money isn't the right way to think about this. It's more of a country-specific number input. Once Auto conversion is turned on there are three inputs on the page. How great would it be if all of them used the same exact input in terms of consistency for the user? 

<img width="504" alt="Screen Shot 2022-03-22 at 9 27 06 AM" src="https://user-images.githubusercontent.com/57100505/159492336-312c02e3-0107-4a94-805a-62a6258a5723.png">

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
