### PR TITLE
refactor(dynamic-flows): Revert default parameter value in helper function

### DIFF
--- a/packages/dynamic-flows/src/flow/DynamicFlow.js
+++ b/packages/dynamic-flows/src/flow/DynamicFlow.js
@@ -35,7 +35,7 @@ const areModelsValid = (formModels, schemas) => {
   return !schemas?.some((schema) => !isValidSchema(formModels[schema.$id] || {}, schema));
 };
 
-const isSubmissionMethod = (method = 'POST') => {
+const isSubmissionMethod = (method) => {
   const submissionMethods = ['POST', 'PUT', 'PATCH'];
   return submissionMethods.includes(method.toUpperCase());
 };


### PR DESCRIPTION
## 🖼 Context

In https://github.com/transferwise/neptune-web/pull/1392 a default value was added for the parameter of `isSubmissionMethod`, for no apparent reason.

Considering that the `requestStep` function uses `GET` as a default when the action method is falsy (DynamicFlow.js line 60). I don't see a reason for the parameter to default to `POST`.

## 🚀 Changes

Revert the change, leaving the function parameter without a default value.

## 🤔 Considerations

We could have defaulted to `GET` but it would make no difference, AFAIK.

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
